### PR TITLE
Allow Relationship in list and detail columns

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -265,8 +265,7 @@ class ModelAdmin(metaclass=ModelAdminMeta):
         count = await cls.count()
         query = select(cls.model).limit(page_size).offset((page - 1) * page_size)
 
-        for list_attr in cls.get_list_columns():
-            _, attr = list_attr
+        for _, attr in cls.get_list_columns():
             if isinstance(attr, RelationshipProperty):
                 query = query.options(selectinload(attr.key))
 
@@ -292,8 +291,7 @@ class ModelAdmin(metaclass=ModelAdminMeta):
     async def get_model_by_pk(cls, value: Any) -> Any:
         query = select(cls.model).where(cls.pk_column == value)
 
-        for list_attr in cls.get_list_columns():
-            _, attr = list_attr
+        for _, attr in cls.get_list_columns():
             if isinstance(attr, RelationshipProperty):
                 query = query.options(selectinload(attr.key))
 
@@ -359,12 +357,7 @@ class ModelAdmin(metaclass=ModelAdminMeta):
             attrs = [getattr(cls.model, cls.pk_column.name).prop]
 
         labels = cls.get_column_labels()
-        list_columns = []
-
-        for attr in attrs:
-            list_columns.append((labels.get(attr, attr.key), attr))
-
-        return list_columns
+        return [(labels.get(attr, attr.key), attr) for attr in attrs]
 
     @classmethod
     def get_details_columns(cls) -> List[Tuple[str, Column]]:
@@ -385,12 +378,8 @@ class ModelAdmin(metaclass=ModelAdminMeta):
             attrs = cls.get_model_attributes()
 
         labels = cls.get_column_labels()
-        details_columns = []
+        return [(labels.get(attr, attr.key), attr) for attr in attrs]
 
-        for attr in attrs:
-            details_columns.append((labels.get(attr, attr.key), attr))
-
-        return details_columns
 
     @classmethod
     def get_column_labels(cls) -> Dict[Column, str]:

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -380,7 +380,6 @@ class ModelAdmin(metaclass=ModelAdminMeta):
         labels = cls.get_column_labels()
         return [(labels.get(attr, attr.key), attr) for attr in attrs]
 
-
     @classmethod
     def get_column_labels(cls) -> Dict[Column, str]:
         return {

--- a/sqladmin/templates/detail.html
+++ b/sqladmin/templates/detail.html
@@ -3,7 +3,7 @@
 <div class="col-12">
   <div class="card">
     <div class="card-header">
-      <h3 class="card-title">{{ model_admin.pk_column.name }}: {{ model_admin.get_column_value(model, model_admin.pk_column) }}</h3>
+      <h3 class="card-title">{{ model_admin.pk_column.name }}: {{ model_admin.get_attr_value(model, model_admin.pk_column) }}</h3>
     </div>
     <div class="card-body border-bottom py-3">
       <div class="table-responsive">
@@ -18,7 +18,7 @@
             {% for name, column in model_admin.get_details_columns() %}
             <tr>
               <td>{{ name }}</td>
-              <td>{{ model_admin.get_column_value(model, column) }}</td>
+              <td>{{ model_admin.get_attr_value(model, column) }}</td>
             </tr>
             {% endfor %}
           </tbody>
@@ -33,7 +33,7 @@
           </div>
           {% if model_admin.can_delete %}
           <div class="col">
-            <a href="#" data-name="{{ model_admin.name }}" data-pk="{{ model_admin.get_column_value(model, model_admin.pk_column) }}" data-url="{{ url_for('admin:delete', identity=model_admin.identity, pk=model_admin.get_column_value(model, model_admin.pk_column)) }}" data-bs-toggle="modal" data-bs-target="#modal-delete" class="btn btn-danger">
+            <a href="#" data-name="{{ model_admin.name }}" data-pk="{{ model_admin.get_attr_value(model, model_admin.pk_column) }}" data-url="{{ url_for('admin:delete', identity=model_admin.identity, pk=model_admin.get_attr_value(model, model_admin.pk_column)) }}" data-bs-toggle="modal" data-bs-target="#modal-delete" class="btn btn-danger">
               Delete
             </a>
           </div>

--- a/sqladmin/templates/list.html
+++ b/sqladmin/templates/list.html
@@ -50,7 +50,7 @@
             <td><input class="form-check-input m-0 align-middle" type="checkbox" aria-label="Select item"></td>
             <td class="text-end">
               {% if model_admin.can_view_details %}
-              <a href="{{ url_for('admin:detail', identity=model_admin.identity, pk=model_admin.get_column_value(row, model_admin.pk_column)) }}" data-bs-toggle="tooltip" data-bs-placement="top" title="View">
+              <a href="{{ url_for('admin:detail', identity=model_admin.identity, pk=model_admin.get_attr_value(row, model_admin.pk_column)) }}" data-bs-toggle="tooltip" data-bs-placement="top" title="View">
                 <span class="me-1"><i class="fas fa-eye"></i></span>
               </a>
               {% endif %}
@@ -60,13 +60,13 @@
               </a>
               {% endif %}
               {% if model_admin.can_delete %}
-              <a href="#" data-name="{{ model_admin.name }}" data-pk="{{ model_admin.get_column_value(row, model_admin.pk_column) }}" data-url="{{ url_for('admin:delete', identity=model_admin.identity, pk=model_admin.get_column_value(row, model_admin.pk_column)) }}" data-bs-toggle="modal" data-bs-target="#modal-delete" title="Delete">
+              <a href="#" data-name="{{ model_admin.name }}" data-pk="{{ model_admin.get_attr_value(row, model_admin.pk_column) }}" data-url="{{ url_for('admin:delete', identity=model_admin.identity, pk=model_admin.get_attr_value(row, model_admin.pk_column)) }}" data-bs-toggle="modal" data-bs-target="#modal-delete" title="Delete">
                 <span class="me-1"><i class="fas fa-trash"></i></span>
               </a>
               {% endif %}
             </td>
             {% for _, column in model_admin.get_list_columns() %}
-            <td>{{ model_admin.get_column_value(row, column) }}</td>
+            <td>{{ model_admin.get_attr_value(row, column) }}</td>
             {% endfor %}
           </tr>
           {% endfor %}

--- a/tests/test_admin_async.py
+++ b/tests/test_admin_async.py
@@ -37,6 +37,9 @@ class User(Base):
 
     addresses = relationship("Address", back_populates="user")
 
+    def __str__(self) -> str:
+        return f"User {self.id}"
+
 
 class Address(Base):
     __tablename__ = "addresses"
@@ -45,6 +48,9 @@ class Address(Base):
     user_id = Column(Integer, ForeignKey("users.id"))
 
     user = relationship("User", back_populates="addresses")
+
+    def __str__(self) -> str:
+        return f"Address {self.id}"
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -203,6 +209,11 @@ async def test_not_found_detail_page() -> None:
 async def test_detail_page() -> None:
     user = User(name="Amin Alaee")
     session.add(user)
+    await session.flush()
+
+    for _ in range(2):
+        address = Address(user_id=user.id)
+        session.add(address)
     await session.commit()
 
     with TestClient(app) as client:
@@ -215,6 +226,8 @@ async def test_detail_page() -> None:
     assert response.text.count("<td>1</td>") == 1
     assert response.text.count("<td>name</td>") == 1
     assert response.text.count("<td>Amin Alaee</td>") == 1
+    assert response.text.count("<td>addresses</td>") == 1
+    assert response.text.count("<td>Address 1, Address 2</td>") == 1
 
     # Action Buttons
     assert response.text.count("http://testserver/admin/user/list") == 2

--- a/tests/test_admin_async.py
+++ b/tests/test_admin_async.py
@@ -59,12 +59,12 @@ async def prepare_database() -> AsyncGenerator[None, None]:
 
 
 class UserAdmin(ModelAdmin, model=User):
-    column_list = [User.id, User.name, User.email]
+    column_list = [User.id, User.name, User.email, User.addresses]
     column_labels = {User.email: "Email"}
 
 
 class AddressAdmin(ModelAdmin, model=Address):
-    column_list = ["id", "user_id"]
+    column_list = ["id", "user_id", "user"]
     name_plural = "Addresses"
     can_edit = False
     can_delete = False

--- a/tests/test_admin_sync.py
+++ b/tests/test_admin_sync.py
@@ -61,12 +61,12 @@ def prepare_database() -> Generator[None, None, None]:
 
 
 class UserAdmin(ModelAdmin, model=User):
-    column_list = [User.id, User.name, User.email]
+    column_list = [User.id, User.name, User.email, User.addresses]
     column_labels = {User.email: "Email"}
 
 
 class AddressAdmin(ModelAdmin, model=Address):
-    column_list = ["id", "user_id"]
+    column_list = ["id", "user_id", "user"]
     name_plural = "Addresses"
     can_edit = False
     can_delete = False

--- a/tests/test_admin_sync.py
+++ b/tests/test_admin_sync.py
@@ -43,6 +43,9 @@ class User(Base):
 
     addresses = relationship("Address", back_populates="user")
 
+    def __str__(self) -> str:
+        return f"User {self.id}"
+
 
 class Address(Base):
     __tablename__ = "addresses"
@@ -51,6 +54,9 @@ class Address(Base):
     user_id = Column(Integer, ForeignKey("users.id"))
 
     user = relationship("User", back_populates="addresses")
+
+    def __str__(self) -> str:
+        return f"Address {self.id}"
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -205,6 +211,11 @@ def test_not_found_detail_page() -> None:
 def test_detail_page() -> None:
     user = User(name="Amin Alaee")
     session.add(user)
+    session.flush()
+
+    for _ in range(2):
+        address = Address(user_id=user.id)
+        session.add(address)
     session.commit()
 
     with TestClient(app) as client:
@@ -217,6 +228,8 @@ def test_detail_page() -> None:
     assert response.text.count("<td>1</td>") == 1
     assert response.text.count("<td>name</td>") == 1
     assert response.text.count("<td>Amin Alaee</td>") == 1
+    assert response.text.count("<td>addresses</td>") == 1
+    assert response.text.count("<td>Address 1, Address 2</td>") == 1
 
     # Action Buttons
     assert response.text.count("http://testserver/admin/user/list") == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -130,14 +130,20 @@ def test_column_exclude_list_by_str_name() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_exclude_list = ["id"]
 
-    assert UserAdmin.get_list_columns() == [("name", User.name)]
+    assert UserAdmin.get_list_columns() == [
+        ("addresses", User.addresses.prop),
+        ("name", User.name),
+    ]
 
 
 def test_column_exclude_list_by_model_column() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_exclude_list = [User.id]
 
-    assert UserAdmin.get_list_columns() == [("name", User.name)]
+    assert UserAdmin.get_list_columns() == [
+        ("addresses", User.addresses.prop),
+        ("name", User.name),
+    ]
 
 
 def test_column_details_list_both_include_and_exclude() -> None:
@@ -156,7 +162,11 @@ def test_column_details_list_default() -> None:
     class UserAdmin(ModelAdmin, model=User):
         pass
 
-    assert UserAdmin.get_details_columns() == [("id", User.id), ("name", User.name)]
+    assert UserAdmin.get_details_columns() == [
+        ("addresses", User.addresses.prop),
+        ("id", User.id),
+        ("name", User.name),
+    ]
 
 
 def test_column_details_list_by_model_column() -> None:
@@ -170,7 +180,10 @@ def test_column_details_exclude_list_by_model_column() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_details_exclude_list = [User.id]
 
-    assert UserAdmin.get_details_columns() == [("name", User.name)]
+    assert UserAdmin.get_details_columns() == [
+        ("addresses", User.addresses.prop),
+        ("name", User.name),
+    ]
 
 
 def test_column_labels_by_string_name() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -130,7 +130,7 @@ def test_column_exclude_list_by_str_name() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_exclude_list = ["id"]
 
-    assert UserAdmin.get_list_columns() == [
+    assert sorted(UserAdmin.get_list_columns()) == [
         ("addresses", User.addresses.prop),
         ("name", User.name),
     ]
@@ -140,7 +140,7 @@ def test_column_exclude_list_by_model_column() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_exclude_list = [User.id]
 
-    assert UserAdmin.get_list_columns() == [
+    assert sorted(UserAdmin.get_list_columns()) == [
         ("addresses", User.addresses.prop),
         ("name", User.name),
     ]
@@ -180,7 +180,7 @@ def test_column_details_exclude_list_by_model_column() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_details_exclude_list = [User.id]
 
-    assert UserAdmin.get_details_columns() == [
+    assert sorted(UserAdmin.get_details_columns()) == [
         ("addresses", User.addresses.prop),
         ("name", User.name),
     ]


### PR DESCRIPTION
Now Relationships can be used in list or detail columns:

```python
class User(Base):
    __tablename__ = "users"

    id = Column(Integer, primary_key=True)
    name = Column(String)
    email = Column(String)
    birthdate = Column(Date)

    addresses = relationship("Address", back_populates="user")


class Address(Base):
    __tablename__ = "addresses"

    id = Column(Integer, primary_key=True)
    user_id = Column(Integer, ForeignKey("users.id"))

    user = relationship("User", back_populates="addresses")


class UserAdmin(ModelAdmin, model=User):
    column_list = [User.id, User.name, User.email, User.addresses]


class AddressAdmin(ModelAdmin, model=Address):
    column_list = [Address.id, Address.user]
    name_plural = "Addresses"

```

Before this `User.addresses` and `Address.user` would not work with SQLAdmin.