### PR TITLE
Adding order_by to list pagination query

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -258,7 +258,12 @@ class ModelAdmin(metaclass=ModelAdminMeta):
         page_size = min(page_size or cls.page_size, max(cls.page_size_options))
 
         count = await cls.count()
-        query = select(cls.model).order_by(cls.pk_column).limit(page_size).offset((page - 1) * page_size)
+        query = (
+            select(cls.model)
+            .order_by(cls.pk_column)
+            .limit(page_size)
+            .offset((page - 1) * page_size)
+        )
 
         pagination = Pagination(
             rows=[],

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -258,8 +258,7 @@ class ModelAdmin(metaclass=ModelAdminMeta):
         page_size = min(page_size or cls.page_size, max(cls.page_size_options))
 
         count = await cls.count()
-        #  sqlalchemy.exc.CompileError: MSSQL requires an order_by when using an OFFSET or a non-simple LIMIT clause
-        query = select(cls.model).order_by("id").limit(page_size).offset((page - 1) * page_size)
+        query = select(cls.model).order_by(cls.pk_column).limit(page_size).offset((page - 1) * page_size)
 
         pagination = Pagination(
             rows=[],

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -258,7 +258,8 @@ class ModelAdmin(metaclass=ModelAdminMeta):
         page_size = min(page_size or cls.page_size, max(cls.page_size_options))
 
         count = await cls.count()
-        query = select(cls.model).limit(page_size).offset((page - 1) * page_size)
+        #  sqlalchemy.exc.CompileError: MSSQL requires an order_by when using an OFFSET or a non-simple LIMIT clause
+        query = select(cls.model).order_by("id").limit(page_size).offset((page - 1) * page_size)
 
         pagination = Pagination(
             rows=[],


### PR DESCRIPTION
To have a consistent query  adding  **ORDER BY** before  "LIMIT" and "OFFSET"  is a must in the models list function.
:-)
 solves #21 