### PR TITLE
Instantiate ModelAdmin internally to avoid class methods

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -38,7 +38,7 @@ class BaseAdmin:
         self.app = app
         self.engine = engine
         self.base_url = base_url
-        self._model_admins: List[Type["ModelAdmin"]] = []
+        self._model_admins: List["ModelAdmin"] = []
 
         self.templates = Jinja2Templates("templates")
         self.templates.env.loader = ChoiceLoader(
@@ -52,7 +52,7 @@ class BaseAdmin:
         self.templates.env.globals["admin_logo_url"] = logo_url
 
     @property
-    def model_admins(self) -> List[Type["ModelAdmin"]]:
+    def model_admins(self) -> List["ModelAdmin"]:
         """Get list of ModelAdmins lazily.
 
         Returns:
@@ -61,7 +61,7 @@ class BaseAdmin:
 
         return self._model_admins
 
-    def _find_model_admin(self, identity: str) -> Type["ModelAdmin"]:
+    def _find_model_admin(self, identity: str) -> "ModelAdmin":
         for model_admin in self.model_admins:
             if model_admin.identity == identity:
                 return model_admin
@@ -97,7 +97,7 @@ class BaseAdmin:
         model.engine = self.engine
         model.sessionmaker = model._get_sessionmaker(model.engine)
 
-        self._model_admins.append(model)
+        self._model_admins.append((model()))
 
 
 class Admin(BaseAdmin):
@@ -137,7 +137,7 @@ class Admin(BaseAdmin):
             engine: SQLAlchemy engine instance.
             base_url: Base URL for Admin interface.
             title: Admin title.
-            logo: URL of logo to be displayed instead of title.
+            logo_url: URL of logo to be displayed instead of title.
         """
 
         assert isinstance(engine, (Engine, AsyncEngine))

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -87,7 +87,7 @@ class ModelAdminMeta(type):
         return cls
 
     @classmethod
-    def _check_conflicting_options(cls, keys: List[str], attrs: dict) -> None:
+    def _check_conflicting_options(mcls, keys: List[str], attrs: dict) -> None:
         if all(k in attrs for k in keys):
             raise AssertionError(f"Cannot use {' and '.join(keys)} together.")
 
@@ -245,32 +245,30 @@ class ModelAdmin(metaclass=ModelAdminMeta):
         ```
     """
 
-    @classmethod
-    async def count(cls) -> int:
-        query = select(func.count(cls.pk_column))
+    async def count(self) -> int:
+        query = select(func.count(self.pk_column))
 
-        if isinstance(cls.engine, Engine):
-            with cls.sessionmaker() as session:
+        if isinstance(self.engine, Engine):
+            with self.sessionmaker() as session:
                 result = await anyio.to_thread.run_sync(session.execute, query)
                 return result.scalar_one()
         else:
-            async with cls.sessionmaker() as session:
+            async with self.sessionmaker() as session:
                 result = await session.execute(query)
                 return result.scalar_one()
 
-    @classmethod
-    async def list(cls, page: int, page_size: int) -> Pagination:
-        page_size = min(page_size or cls.page_size, max(cls.page_size_options))
+    async def list(self, page: int, page_size: int) -> Pagination:
+        page_size = min(page_size or self.page_size, max(self.page_size_options))
 
-        count = await cls.count()
+        count = await self.count()
         query = (
-            select(cls.model)
-            .order_by(cls.pk_column)
+            select(self.model)
+            .order_by(self.pk_column)
             .limit(page_size)
             .offset((page - 1) * page_size)
         )
 
-        for _, attr in cls.get_list_columns():
+        for _, attr in self.get_list_columns():
             if isinstance(attr, RelationshipProperty):
                 query = query.options(selectinload(attr.key))
 
@@ -281,37 +279,35 @@ class ModelAdmin(metaclass=ModelAdminMeta):
             count=count,
         )
 
-        if isinstance(cls.engine, Engine):
-            with cls.sessionmaker() as session:
+        if isinstance(self.engine, Engine):
+            with self.sessionmaker() as session:
                 items = await anyio.to_thread.run_sync(session.execute, query)
                 pagination.rows = items.scalars().all()
                 return pagination
         else:
-            async with cls.sessionmaker() as session:
+            async with self.sessionmaker() as session:
                 items = await session.execute(query)
                 pagination.rows = items.scalars().all()
                 return pagination
 
-    @classmethod
-    async def get_model_by_pk(cls, value: Any) -> Any:
-        query = select(cls.model).where(cls.pk_column == value)
+    async def get_model_by_pk(self, value: Any) -> Any:
+        query = select(self.model).where(self.pk_column == value)
 
-        for _, attr in cls.get_details_columns():
+        for _, attr in self.get_details_columns():
             if isinstance(attr, RelationshipProperty):
                 query = query.options(selectinload(attr.key))
 
-        if isinstance(cls.engine, Engine):
-            with cls.sessionmaker() as session:
+        if isinstance(self.engine, Engine):
+            with self.sessionmaker() as session:
                 result = await anyio.to_thread.run_sync(session.execute, query)
                 return result.scalar_one_or_none()
         else:
-            async with cls.sessionmaker() as session:
+            async with self.sessionmaker() as session:
                 result = await session.execute(query)
                 return result.scalar_one_or_none()
 
-    @classmethod
     def get_attr_value(
-        cls, obj: type, attr: Union[Column, ColumnProperty, RelationshipProperty]
+        self, obj: type, attr: Union[Column, ColumnProperty, RelationshipProperty]
     ) -> Any:
         if isinstance(attr, Column):
             return getattr(obj, attr.name)
@@ -321,9 +317,8 @@ class ModelAdmin(metaclass=ModelAdminMeta):
                 return ", ".join(map(str, value))
             return value
 
-    @classmethod
     def get_model_attr(
-        cls, attr: Union[str, InstrumentedAttribute]
+        self, attr: Union[str, InstrumentedAttribute]
     ) -> Union[ColumnProperty, RelationshipProperty]:
         assert isinstance(attr, (str, InstrumentedAttribute))
 
@@ -335,81 +330,76 @@ class ModelAdmin(metaclass=ModelAdminMeta):
             key = attr.prop.key
 
         try:
-            return inspect(cls.model).attrs[key]
+            return inspect(self.model).attrs[key]
         except KeyError:
             raise InvalidColumnError(
-                f"Model '{cls.model.__name__}' has no attribute '{attr}'."
+                f"Model '{self.model.__name__}' has no attribute '{attr}'."
             )
 
-    @classmethod
-    def get_model_attributes(cls) -> List[Column]:
-        return list(inspect(cls.model).attrs)
+    def get_model_attributes(self) -> List[Column]:
+        return list(inspect(self.model).attrs)
 
-    @classmethod
-    def get_list_columns(cls) -> List[Tuple[str, Column]]:
+    def get_list_columns(self) -> List[Tuple[str, Column]]:
         """Get list of columns to display in List page."""
 
-        column_list = getattr(cls, "column_list", None)
-        column_exclude_list = getattr(cls, "column_exclude_list", None)
+        column_list = getattr(self, "column_list", None)
+        column_exclude_list = getattr(self, "column_exclude_list", None)
 
         if column_list:
-            attrs = [cls.get_model_attr(attr) for attr in cls.column_list]
+            attrs = [self.get_model_attr(attr) for attr in self.column_list]
         elif column_exclude_list:
-            exclude_columns = [cls.get_model_attr(attr) for attr in column_exclude_list]
-            all_attrs = cls.get_model_attributes()
+            exclude_columns = [
+                self.get_model_attr(attr) for attr in column_exclude_list
+            ]
+            all_attrs = self.get_model_attributes()
             attrs = list(set(all_attrs) - set(exclude_columns))
         else:
-            attrs = [getattr(cls.model, cls.pk_column.name).prop]
+            attrs = [getattr(self.model, self.pk_column.name).prop]
 
-        labels = cls.get_column_labels()
+        labels = self.get_column_labels()
         return [(labels.get(attr, attr.key), attr) for attr in attrs]
 
-    @classmethod
-    def get_details_columns(cls) -> List[Tuple[str, Column]]:
+    def get_details_columns(self) -> List[Tuple[str, Column]]:
         """Get list of columns to display in Detail page."""
 
-        column_details_list = getattr(cls, "column_details_list", None)
-        column_details_exclude_list = getattr(cls, "column_details_exclude_list", None)
+        column_details_list = getattr(self, "column_details_list", None)
+        column_details_exclude_list = getattr(self, "column_details_exclude_list", None)
 
         if column_details_list:
-            attrs = [cls.get_model_attr(attr) for attr in column_details_list]
+            attrs = [self.get_model_attr(attr) for attr in column_details_list]
         elif column_details_exclude_list:
             exclude_columns = [
-                cls.get_model_attr(attr) for attr in column_details_exclude_list
+                self.get_model_attr(attr) for attr in column_details_exclude_list
             ]
-            all_attrs = cls.get_model_attributes()
+            all_attrs = self.get_model_attributes()
             attrs = list(set(all_attrs) - set(exclude_columns))
         else:
-            attrs = cls.get_model_attributes()
+            attrs = self.get_model_attributes()
 
-        labels = cls.get_column_labels()
+        labels = self.get_column_labels()
         return [(labels.get(attr, attr.key), attr) for attr in attrs]
 
-    @classmethod
-    def get_column_labels(cls) -> Dict[Column, str]:
+    def get_column_labels(self) -> Dict[Column, str]:
         return {
-            cls.get_model_attr(column_label): value
-            for column_label, value in cls.column_labels.items()
+            self.get_model_attr(column_label): value
+            for column_label, value in self.column_labels.items()
         }
 
-    @classmethod
-    async def delete_model(cls, obj: type) -> None:
-        if isinstance(cls.engine, Engine):
-            with cls.sessionmaker.begin() as session:
+    async def delete_model(self, obj: type) -> None:
+        if isinstance(self.engine, Engine):
+            with self.sessionmaker.begin() as session:
                 await anyio.to_thread.run_sync(session.delete, obj)
         else:
-            async with cls.sessionmaker.begin() as session:
+            async with self.sessionmaker.begin() as session:
                 await session.delete(obj)
 
-    @classmethod
-    async def insert_model(cls, obj: type) -> Any:
-        if isinstance(cls.engine, Engine):
-            with cls.sessionmaker.begin() as session:
+    async def insert_model(self, obj: type) -> Any:
+        if isinstance(self.engine, Engine):
+            with self.sessionmaker.begin() as session:
                 await anyio.to_thread.run_sync(session.add, obj)
         else:
-            async with cls.sessionmaker.begin() as session:
+            async with self.sessionmaker.begin() as session:
                 session.add(obj)
 
-    @classmethod
-    async def scaffold_form(cls) -> Type[Form]:
-        return await get_model_form(model=cls.model, engine=cls.engine)
+    async def scaffold_form(self) -> Type[Form]:
+        return await get_model_form(model=self.model, engine=self.engine)

--- a/tests/test_admin_async.py
+++ b/tests/test_admin_async.py
@@ -294,14 +294,14 @@ async def test_delete_endpoint() -> None:
 
 
 async def test_create_endpoint_unauthorized_response() -> None:
-    admin._model_admins[1].can_create = False
+    admin._model_admins[1].can_create = False  # type: ignore
 
     with TestClient(app) as client:
         response = client.get("/admin/address/create")
 
     assert response.status_code == 401
 
-    admin._model_admins[1].can_create = True
+    admin._model_admins[1].can_create = True  # type: ignore
 
 
 async def test_create_endpoint_get_form() -> None:

--- a/tests/test_admin_sync.py
+++ b/tests/test_admin_sync.py
@@ -288,14 +288,14 @@ def test_delete_endpoint() -> None:
 
 
 def test_create_endpoint_unauthorized_response() -> None:
-    admin._model_admins[1].can_create = False
+    admin._model_admins[1].can_create = False  # type: ignore
 
     with TestClient(app) as client:
         response = client.get("/admin/address/create")
 
     assert response.status_code == 401
 
-    admin._model_admins[1].can_create = True
+    admin._model_admins[1].can_create = True  # type: ignore
 
 
 def test_create_endpoint_get_form() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -86,7 +86,7 @@ def test_column_list_default() -> None:
     class UserAdmin(ModelAdmin, model=User):
         pass
 
-    assert UserAdmin.get_list_columns() == [("id", User.id)]
+    assert UserAdmin().get_list_columns() == [("id", User.id)]
 
 
 def test_column_list_by_model_columns() -> None:
@@ -100,7 +100,7 @@ def test_column_list_by_str_name() -> None:
     class AddressAdmin(ModelAdmin, model=Address):
         column_list = ["id", "user_id"]
 
-    assert AddressAdmin.get_list_columns() == [
+    assert AddressAdmin().get_list_columns() == [
         ("id", Address.id),
         ("user_id", Address.user_id),
     ]
@@ -111,7 +111,7 @@ def test_column_list_invalid_attribute() -> None:
         column_list = ["example"]
 
     with pytest.raises(InvalidColumnError) as exc:
-        ExampleAdmin.get_list_columns()
+        ExampleAdmin().get_list_columns()
 
     assert exc.match("Model 'Address' has no attribute 'example'.")
 
@@ -130,7 +130,7 @@ def test_column_exclude_list_by_str_name() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_exclude_list = ["id"]
 
-    assert sorted(UserAdmin.get_list_columns()) == [
+    assert sorted(UserAdmin().get_list_columns()) == [
         ("addresses", User.addresses.prop),
         ("name", User.name),
     ]
@@ -140,7 +140,7 @@ def test_column_exclude_list_by_model_column() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_exclude_list = [User.id]
 
-    assert sorted(UserAdmin.get_list_columns()) == [
+    assert sorted(UserAdmin().get_list_columns()) == [
         ("addresses", User.addresses.prop),
         ("name", User.name),
     ]
@@ -162,7 +162,7 @@ def test_column_details_list_default() -> None:
     class UserAdmin(ModelAdmin, model=User):
         pass
 
-    assert UserAdmin.get_details_columns() == [
+    assert UserAdmin().get_details_columns() == [
         ("addresses", User.addresses.prop),
         ("id", User.id),
         ("name", User.name),
@@ -173,14 +173,14 @@ def test_column_details_list_by_model_column() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_details_list = [User.name, User.id]
 
-    assert UserAdmin.get_details_columns() == [("name", User.name), ("id", User.id)]
+    assert UserAdmin().get_details_columns() == [("name", User.name), ("id", User.id)]
 
 
 def test_column_details_exclude_list_by_model_column() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_details_exclude_list = [User.id]
 
-    assert sorted(UserAdmin.get_details_columns()) == [
+    assert sorted(UserAdmin().get_details_columns()) == [
         ("addresses", User.addresses.prop),
         ("name", User.name),
     ]
@@ -191,13 +191,13 @@ def test_column_labels_by_string_name() -> None:
         column_list = [User.name]
         column_labels = {"name": "Name"}
 
-    assert UserAdmin.get_list_columns() == [("Name", User.name)]
+    assert UserAdmin().get_list_columns() == [("Name", User.name)]
 
     class AddressAdmin(ModelAdmin, model=Address):
         column_details_list = [Address.user_id]
         column_labels = {"user_id": "User ID"}
 
-    assert AddressAdmin.get_details_columns() == [("User ID", Address.user_id)]
+    assert AddressAdmin().get_details_columns() == [("User ID", Address.user_id)]
 
 
 def test_column_labels_by_model_columns() -> None:
@@ -205,10 +205,10 @@ def test_column_labels_by_model_columns() -> None:
         column_list = [User.name]
         column_labels = {User.name: "Name"}
 
-    assert UserAdmin.get_list_columns() == [("Name", User.name)]
+    assert UserAdmin().get_list_columns() == [("Name", User.name)]
 
     class AddressAdmin(ModelAdmin, model=Address):
         column_details_list = [Address.user_id]
         column_labels = {Address.user_id: "User ID"}
 
-    assert AddressAdmin.get_details_columns() == [("User ID", Address.user_id)]
+    assert AddressAdmin().get_details_columns() == [("User ID", Address.user_id)]


### PR DESCRIPTION
Right now all internal methods of ModelAdmin are class methods. This change will keep the same API for users but instantiate ModelAdmin internally to have normal methods instead.