### PR TITLE
Add form-specific functionality to ModelAdmin

### DIFF
--- a/docs/api_reference/model_admin.md
+++ b/docs/api_reference/model_admin.md
@@ -30,3 +30,4 @@
         - form_args
         - form_columns
         - form_excluded_columns
+        - form_overrides

--- a/docs/api_reference/model_admin.md
+++ b/docs/api_reference/model_admin.md
@@ -27,5 +27,6 @@
         - column_sortable_list
         - form
         - form_base_class
+        - form_args
         - form_columns
         - form_excluded_columns

--- a/docs/api_reference/model_admin.md
+++ b/docs/api_reference/model_admin.md
@@ -25,3 +25,7 @@
         - column_searchable_list
         - search_placeholder
         - column_sortable_list
+        - form
+        - form_base_class
+        - form_columns
+        - form_excluded_columns

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -256,6 +256,7 @@ async def get_model_form(
     engine: Union[Engine, AsyncEngine],
     only: Sequence[str] = None,
     exclude: Sequence[str] = None,
+    form_class: Type[Form] = Form,
 ) -> Type[Form]:
     type_name = model.__name__ + "Form"
     converter = ModelConverter()
@@ -276,4 +277,4 @@ async def get_model_form(
         if field is not None:
             field_dict[name] = field
 
-    return type(type_name, (Form,), field_dict)
+    return type(type_name, (form_class,), field_dict)

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -80,7 +80,7 @@ class ModelConverterBase:
         prop: Union[ColumnProperty, RelationshipProperty],
         engine: Union[Engine, AsyncEngine],
         label: Optional[str] = None,
-        field_args: Optional[Dict[str, Any]] = None
+        field_args: Optional[Dict[str, Any]] = None,
     ) -> UnboundField:
         if field_args is not None:
             kwargs = field_args.copy()

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -85,11 +85,11 @@ class ModelConverterBase:
         mapper: Mapper,
         prop: Union[ColumnProperty, RelationshipProperty],
         engine: Union[Engine, AsyncEngine],
+        field_args: Dict[str, Any] = None,
         label: Optional[str] = None,
-        field_args: Optional[Dict[str, Any]] = None,
         override: Optional[Type[Field]] = None,
     ) -> UnboundField:
-        if field_args is not None:
+        if field_args:
             kwargs = field_args.copy()
         else:
             kwargs = {}
@@ -269,9 +269,9 @@ async def get_model_form(
     only: Sequence[str] = None,
     exclude: Sequence[str] = None,
     column_labels: Dict[str, str] = None,
-    form_args: Optional[Dict[str, Dict[str, Any]]] = None,
+    form_args: Dict[str, Dict[str, Any]] = None,
     form_class: Type[Form] = Form,
-    form_overrides: Optional[Dict[str, Dict[str, Type[Field]]]] = None,
+    form_overrides: Dict[str, Dict[str, Type[Field]]] = None,
 ) -> Type[Form]:
     type_name = model.__name__ + "Form"
     converter = ModelConverter()
@@ -291,11 +291,11 @@ async def get_model_form(
 
     field_dict = {}
     for name, attr in attributes:
-        field_args = form_args.get(name, None)
+        field_args = form_args.get(name, {})
         label = column_labels.get(name, None)
         override = form_overrides.get(name, None)
         field = await converter.convert(
-            model, mapper, attr, engine, label, field_args, override
+            model, mapper, attr, engine, field_args, label, override
         )
         if field is not None:
             field_dict[name] = field

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -304,7 +304,7 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
         ```
     """
 
-    form_base_class: ClassVar[Optional[Type[Form]]] = Form
+    form_base_class: ClassVar[Type[Form]] = Form
     """Base form class.
     Will be used by form scaffolding function when creating model form.
     Useful if you want to have custom constructor or override some fields.
@@ -320,7 +320,7 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
         ```
     """
 
-    form_args: ClassVar[Optional[Dict[str, Dict[str, Any]]]] = None
+    form_args: ClassVar[Dict[str, Dict[str, Any]]] = {}
     """Dictionary of form field arguments.
     Refer to WTForms documentation for list of possible options.
 
@@ -360,7 +360,7 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
         ```
     """
 
-    form_overrides: ClassVar[Optional[Dict[str, Type[Field]]]] = None
+    form_overrides: ClassVar[Dict[str, Type[Field]]] = {}
     """Dictionary of form column overrides.
 
     ???+ example

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -27,7 +27,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import ClauseElement
 from starlette.requests import Request
-from wtforms import Form
+from wtforms import Field, Form
 
 from sqladmin.exceptions import InvalidColumnError, InvalidModelError
 from sqladmin.forms import get_model_form
@@ -360,6 +360,16 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
         ```
     """
 
+    form_overrides: ClassVar[Optional[Dict[str, Type[Field]]]] = None
+    """Dictionary of form column overrides.
+
+    ???+ example
+        ```python
+        class UserAdmin(ModelAdmin, model=User):
+            form_overrides = dict(name=wtf.FileField)
+        ```
+    """
+
     def __init__(self) -> None:
         self._column_labels = self.get_column_labels()
 
@@ -630,6 +640,7 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
             column_labels={k.key: v for k, v in self._column_labels.items()},
             form_args=self.form_args,
             form_class=self.form_base_class,
+            form_overrides=self.form_overrides,
         )
 
     def search_placeholder(self) -> str:

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -320,6 +320,21 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
         ```
     """
 
+    form_args: ClassVar[Optional[Dict[str, Dict[str, Any]]]] = None
+    """Dictionary of form field arguments.
+    Refer to WTForms documentation for list of possible options.
+
+    ???+ example
+        ```python
+        from wtforms.validators import DataRequired
+
+        class MyModelAdmin(ModelAdmin, model=User):
+            form_args = dict(
+                name=dict(label="User Name", validators=[DataRequired()])
+            )
+        ```
+    """
+
     form_columns: ClassVar[Sequence[Union[str, InstrumentedAttribute]]] = []
     """List of columns to include in the form.
     Columns can either be string names or SQLAlchemy columns.
@@ -612,6 +627,8 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
             model=self.model,
             engine=self.engine,
             only=[i[1].key for i in self.get_form_columns()],
+            column_labels={k.key: v for k, v in self._column_labels.items()},
+            form_args=self.form_args,
             form_class=self.form_base_class,
         )
 

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -538,9 +538,8 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
         exclude: Optional[Sequence[Union[str, InstrumentedAttribute]]] = None,
         default: Callable[[], List[Column]] = None,
     ) -> List[Tuple[str, Column]]:
-        """Many situations in the code call for constructing a list of columns.
-        This function generalizes this pattern for any sequence of inclusions
-        or exclusions.
+        """This function generalizes constructing a list of columns
+        for any sequence of inclusions or exclusions.
         """
         if include:
             attrs = [self.get_model_attr(attr) for attr in include]

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -23,7 +23,6 @@ from wtforms import Field, Form, StringField
 from sqladmin import ModelAdmin
 from sqladmin.forms import get_model_form
 from tests.common import async_engine as engine
-from tests.test_models import User
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -18,6 +18,7 @@ from sqlalchemy.dialects.postgresql import INET, MACADDR, UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
+from wtforms import Field
 
 from sqladmin.forms import get_model_form
 from tests.common import async_engine as engine
@@ -129,6 +130,17 @@ async def test_model_form_column_label_precedence(client: AsyncClient) -> None:
         column_labels=labels_user,
     )
     assert Form()._fields["user"].label.text == "User (Use Me)"
+
+
+async def test_model_form_override(client: AsyncClient) -> None:
+    class ExampleField(Field):
+        pass
+
+    Form = await get_model_form(
+        model=User, engine=engine, form_overrides={"name": ExampleField}
+    )
+    assert isinstance(Form()._fields["name"], ExampleField)
+    assert not isinstance(Form()._fields["email"], ExampleField)
 
 
 @pytest.mark.skipif(engine.name != "postgresql", reason="PostgreSQL only")

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -98,6 +98,14 @@ async def test_model_form_exclude(client: AsyncClient) -> None:
     assert len(Form()._fields) == 8
 
 
+async def test_model_form_form_args(client: AsyncClient) -> None:
+    form_args = {
+        "name": {"label": "User Name"}
+    }
+    Form = await get_model_form(model=User, engine=engine, form_args=form_args)
+    assert Form()._fields["name"].label.text == "User Name"
+
+
 @pytest.mark.skipif(engine.name != "postgresql", reason="PostgreSQL only")
 async def test_model_form_postgresql(client: AsyncClient) -> None:
     class PostgresModel(Base):


### PR DESCRIPTION
I added the following attributes to `ModelAdmin`:

* `form`
* `form_base_class`
* `form_args`
* `form_columns`
* `form_excluded_columns`
* `form_overrides`

All of these attributes emulate their respective functionality in the Flask-Admin API: https://flask-admin.readthedocs.io/en/latest/api/mod_model/

This PR addresses issue #96.

--

Note that I abstracted out the `get_{x}_columns()` functionality in `ModelAdmin`. Let me know if you want me to revert this back to being repetitive.

---

~~As of writing, there is one thing currently missing from my PR: the scaffolding does _not_ make use of `column_labels`. This is something I will hope to finish up soon!~~

Let me know what other changes you want me to make.