### PR TITLE
Version 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.1.7 - 2022-03-22
+
+### Added
+
+* Add SQLModel support by @aminalaee in https://github.com/aminalaee/sqladmin/pull/94
+* Add form-specific functionality to ModelAdmin by @dwreeves in https://github.com/aminalaee/sqladmin/pull/97
+* Add `UUID` field converter by @aminalaee in https://github.com/aminalaee/sqladmin/pull/82
+* Add PostgreSQL `INET` and `MACADDR` converters by @aminalaee in https://github.com/aminalaee/sqladmin/pull/83
+
+### Fixed
+
+* Fix Boolean field checkbox UI by @aminalaee in https://github.com/aminalaee/sqladmin/pull/88
+* Fix PostgreSQL UUID PrimaryKey by @aminalaee in https://github.com/aminalaee/sqladmin/pull/92
+* Fix Source Code Link by @baurt in https://github.com/aminalaee/sqladmin/pull/95
+
+## New Contributors
+* @baurt made their first contribution in https://github.com/aminalaee/sqladmin/pull/95
+* @dwreeves made their first contribution in https://github.com/aminalaee/sqladmin/pull/97
+
+**Full Changelog**: https://github.com/aminalaee/sqladmin/compare/0.1.6...0.1.7
+
 ## Version 0.1.6 - 2022-03-09
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,18 +4,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.1.7 - 2022-03-22
+
+### Added
+
+* Add SQLModel support in [#94](https://github.com/aminalaee/sqladmin/pull/94)
+* Add form-specific functionality to ModelAdmin in [#97](https://github.com/aminalaee/sqladmin/pull/97)
+* Add `UUID` field converter in [#82](https://github.com/aminalaee/sqladmin/pull/82)
+* Add PostgreSQL `INET` and `MACADDR` converters in [#83](https://github.com/aminalaee/sqladmin/pull/83)
+
+### Fixed
+
+* Fix Boolean field checkbox UI in [#88](https://github.com/aminalaee/sqladmin/pull/88)
+* Fix PostgreSQL UUID PrimaryKey in [#92](https://github.com/aminalaee/sqladmin/pull/92)
+* Fix Source Code Link in [#95](https://github.com/aminalaee/sqladmin/pull/95)
+
+**Full Changelog**: https://github.com/aminalaee/sqladmin/compare/0.1.6...0.1.7
+
 ## Version 0.1.6 - 2022-03-09
 
 ### Added
 
-* FontAwesome6 icons in https://github.com/aminalaee/sqladmin/pull/78
-* Add `column_sortable_list` in https://github.com/aminalaee/sqladmin/pull/65
-* Add JSON column converters in https://github.com/aminalaee/sqladmin/pull/74
+* FontAwesome6 icons in [#78](https://github.com/aminalaee/sqladmin/pull/78)
+* Add `column_sortable_list` in [#65](https://github.com/aminalaee/sqladmin/pull/65)
+* Add JSON column converters in [#74](https://github.com/aminalaee/sqladmin/pull/74)
 
 ### Fixed
 
-* Fix URL search regex in https://github.com/aminalaee/sqladmin/pull/67
-* Fix Enum in Edit page in https://github.com/aminalaee/sqladmin/pull/71
+* Fix URL search regex in [#67](https://github.com/aminalaee/sqladmin/pull/67)
+* Fix Enum in Edit page in [#71](https://github.com/aminalaee/sqladmin/pull/71)
 
 **Full Changelog**: https://github.com/aminalaee/sqladmin/compare/0.1.5...0.1.6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sqladmin
-version = 0.1.6
+version = 0.1.7
 author = Amin Alaee
 author_email = mohammadamin.alaee@gmail.com
 description = Admin interface for SQLAlchemy.

--- a/sqladmin/__init__.py
+++ b/sqladmin/__init__.py
@@ -1,7 +1,7 @@
 from sqladmin.application import Admin
 from sqladmin.models import ModelAdmin
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 __all__ = [
     "Admin",


### PR DESCRIPTION
## Version 0.1.7 - 2022-03-22

### Added

* Add SQLModel support by @aminalaee in https://github.com/aminalaee/sqladmin/pull/94
* Add form-specific functionality to ModelAdmin by @dwreeves in https://github.com/aminalaee/sqladmin/pull/97
* Add `UUID` field converter by @aminalaee in https://github.com/aminalaee/sqladmin/pull/82
* Add PostgreSQL `INET` and `MACADDR` converters by @aminalaee in https://github.com/aminalaee/sqladmin/pull/83

### Fixed

* Fix Boolean field checkbox UI by @aminalaee in https://github.com/aminalaee/sqladmin/pull/88
* Fix PostgreSQL UUID PrimaryKey by @aminalaee in https://github.com/aminalaee/sqladmin/pull/92
* Fix Source Code Link by @baurt in https://github.com/aminalaee/sqladmin/pull/95