### PR TITLE
fix docstring issues by adding an explicit handler

### DIFF
--- a/docs/api_reference/model_admin.md
+++ b/docs/api_reference/model_admin.md
@@ -31,7 +31,6 @@
         - export_types
         - export_max_rows
         - form
-        - form_base_class
         - form_args
         - form_columns
         - form_excluded_columns

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sqlmodel==0.0.6
 
 # Tests
 autoflake==1.4
-black==22.3.0
+black==22.1.0
 coverage==6.3.2
 flake8==4.0.1
 httpx==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sqlmodel==0.0.6
 
 # Tests
 autoflake==1.4
-black==22.1.0
+black==22.3.0
 coverage==6.3.2
 flake8==4.0.1
 httpx==0.22.0


### PR DESCRIPTION
Long story short: fixes #104.

Locking the dependency uses mkdocstrings's so-called "experimental" handler for docstring parsing. The new one properly parses the docstring in this case whereas the legacy one does not.