### PR TITLE
Refactor `forms.py` (Work in progress)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sqlmodel==0.0.6
 
 # Tests
 autoflake==1.4
-black==22.1.0
+black==22.3.0
 coverage==6.3.2
 flake8==4.0.1
 httpx==0.22.0

--- a/sqladmin/exceptions.py
+++ b/sqladmin/exceptions.py
@@ -1,6 +1,14 @@
-class InvalidModelError(Exception):
+class SQLAdminException(Exception):
     pass
 
 
-class InvalidColumnError(Exception):
+class InvalidModelError(SQLAdminException):
+    pass
+
+
+class InvalidColumnError(SQLAdminException):
+    pass
+
+
+class NoConverterFound(SQLAdminException):
     pass

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -1,13 +1,20 @@
 import inspect
 from enum import Enum
-from typing import Any, Callable, Dict, Optional, Sequence, Type, Union, no_type_check
+from typing import Any, Callable, Dict, List, Optional, Sequence, Type, TypeVar, Union
 
 import anyio
 from sqlalchemy import inspect as sqlalchemy_inspect, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
-from sqlalchemy.orm import ColumnProperty, Mapper, RelationshipProperty, Session
+from sqlalchemy.orm import (
+    ColumnProperty,
+    InstrumentedAttribute,
+    MapperProperty,
+    RelationshipProperty,
+    Session,
+)
 from sqlalchemy.sql.schema import Column
+from typing_extensions import Protocol
 from wtforms import (
     BooleanField,
     DateField,
@@ -23,37 +30,178 @@ from wtforms import (
 )
 from wtforms.fields.core import UnboundField
 
+from sqladmin.exceptions import NoConverterFound
 from sqladmin.fields import JSONField, QuerySelectField, QuerySelectMultipleField
 
+T_MP = TypeVar("T_MP", ColumnProperty, RelationshipProperty)
 
-@no_type_check
-def converts(*args: str) -> Callable:
-    def _inner(func: Callable) -> Callable:
-        func._converter_for = frozenset(args)
-        return func
 
-    return _inner
+class Validator(Protocol):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        ...
+
+    def __call__(self, form: Form, field: Field) -> None:
+        ...
+
+
+class ConverterCallback(Protocol):
+    def __call__(self, model: type, prop: T_MP, kwargs: Dict[str, Any]) -> UnboundField:
+        ...
+
+
+T_CC = TypeVar("T_CC", bound=ConverterCallback)
+
+
+class AdminAttribute:
+    def __init__(
+        self,
+        model: type,
+        attribute: Union[str, InstrumentedAttribute],
+        *,
+        label: Optional[str] = None,
+        field_type_override: Type[Field] = None,
+        extra_field_kwargs: Dict[str, Any] = None,
+        extra_validators: List[Callable[[Form, Field], None]] = None,
+    ):
+        self.model = model
+
+        if isinstance(attribute, str):
+            self.attribute = getattr(model, attribute)
+        else:
+            self.attribute = attribute  # pragma: no cover
+        assert isinstance(self.attribute, InstrumentedAttribute)
+        assert self.attribute.class_ is model
+
+        self.label = label
+
+        self.extra_field_kwargs = extra_field_kwargs or {}
+        self.field_type_override = field_type_override
+        self.extra_validators = extra_validators or []
+
+    def skip(self) -> bool:
+        if self.is_relationship:
+            return False
+        else:
+            return bool(self.sqla_column.primary_key or self.sqla_column.foreign_keys)
+
+    @property
+    def is_relationship(self) -> bool:
+        return isinstance(self.attribute.prop, RelationshipProperty)
+
+    @property
+    def sqla_property(self) -> MapperProperty:
+        return self.attribute.prop
+
+    @property
+    def sqla_column(self) -> Column:
+        assert isinstance(
+            self.sqla_property, ColumnProperty
+        ), "Relationship properties don't have a column attr"
+        assert (
+            len(self.sqla_property.columns) == 1
+        ), "Multiple-column properties not supported"
+        column = self.sqla_property.columns[0]
+        return column
+
+    def _get_default_value(self) -> Any:
+        if self.is_relationship:
+            return None
+
+        default = getattr(self.sqla_column, "default", None)
+
+        if default is not None:
+            # Only actually change default if it has an attribute named
+            # 'arg' that's callable.
+            callable_default = getattr(default, "arg", None)
+
+            if callable_default is not None:
+                # ColumnDefault(val).arg can be also a plain value
+                default = (
+                    callable_default(None)
+                    if callable(callable_default)
+                    else callable_default
+                )
+
+        return default
+
+    @property
+    def wtf_base_validators(self) -> List[Validator]:
+        if self.is_relationship:
+            return []
+        li = []
+        if self.sqla_column.nullable:
+            li.append(validators.Optional())
+        else:
+            li.append(validators.InputRequired())
+        return li
+
+    @property
+    def _wtf_default_field_kwargs(self) -> Dict[str, Any]:
+        kwargs = {
+            "label": self.label,
+            "validators": [*self.wtf_base_validators, *self.extra_validators],
+            "description": self.sqla_property.doc,
+            "render_kw": {"class": "form-control"},
+            "default": self._get_default_value(),
+        }
+        if self.is_relationship:
+            allow_blank = True
+            for pair in self.sqla_property.local_remote_pairs:
+                if not pair[0].nullable:
+                    allow_blank = False
+            kwargs["allow_blank"] = allow_blank
+        return kwargs
+
+    async def get_object_list(self, engine: Union[Engine, AsyncEngine]) -> List[Any]:
+        target_model = self.sqla_property.mapper.class_
+        pk = sqlalchemy_inspect(target_model).primary_key[0].name
+        stmt = select(target_model)
+
+        if isinstance(engine, Engine):
+            with Session(engine) as session:
+                objects = await anyio.to_thread.run_sync(session.execute, stmt)
+                object_list = [
+                    (str(getattr(obj, pk)), obj) for obj in objects.scalars().all()
+                ]
+        else:
+            async with AsyncSession(engine) as session:
+                objects = await session.execute(stmt)
+                object_list = [
+                    (str(getattr(obj, pk)), obj) for obj in objects.scalars().all()
+                ]
+        return object_list
+
+    @property
+    def field_kwargs(self) -> Dict[str, Any]:
+        d = {
+            **self._wtf_default_field_kwargs,
+            **self.extra_field_kwargs,
+        }
+        return d
 
 
 class ModelConverterBase:
-    _convert_for = None
 
-    def __init__(self) -> None:
-        converters = {}
+    _callbacks: Dict[str, ConverterCallback] = {}
 
+    def __init__(self):
+        super().__init__()
+        self._register_callbacks()
+
+    def _register_callbacks(self):
+        converters: Dict[str, ConverterCallback] = {}
         for name in dir(self):
             obj = getattr(self, name)
             if hasattr(obj, "_converter_for"):
                 for classname in obj._converter_for:
                     converters[classname] = obj
+        self._callbacks = converters
 
-        self.converters = converters
-
-    def get_converter(
-        self, prop: Union[ColumnProperty, RelationshipProperty]
-    ) -> Callable:
-        if not isinstance(prop, ColumnProperty):
-            return self.converters[prop.direction.name]
+    def get_callback(
+        self, model: type, prop: T_MP, kwargs: Dict[str, Any]
+    ) -> ConverterCallback:
+        if isinstance(prop, RelationshipProperty):
+            return self._callbacks[prop.direction.name]
 
         column = prop.columns[0]
         types = inspect.getmro(type(column.type))
@@ -62,205 +210,162 @@ class ModelConverterBase:
         for col_type in types:
             type_string = f"{col_type.__module__}.{col_type.__name__}"
 
-            if type_string in self.converters:
-                return self.converters[type_string]
+            if type_string in self._callbacks:
+                return self._callbacks[type_string]
 
         # Search by name
         for col_type in types:
-            if col_type.__name__ in self.converters:
-                return self.converters[col_type.__name__]
+            if col_type.__name__ in self._callbacks:
+                return self._callbacks[col_type.__name__]
 
             # Support for custom types like SQLModel which inherit TypeDecorator
             if hasattr(col_type, "impl"):
-                if col_type.impl.__name__ in self.converters:  # type: ignore
-                    return self.converters[col_type.impl.__name__]  # type: ignore
+                if col_type.impl.__name__ in self._callbacks:  # type: ignore
+                    return self._callbacks[col_type.impl.__name__]  # type: ignore
 
-        raise Exception(  # pragma: nocover
+        raise NoConverterFound(  # pragma: nocover
             f"Could not find field converter for column {column.name} ({types[0]!r})."
         )
 
-    async def convert(
-        self,
-        model: type,
-        mapper: Mapper,
-        prop: Union[ColumnProperty, RelationshipProperty],
-        engine: Union[Engine, AsyncEngine],
-        field_args: Dict[str, Any] = None,
-        label: Optional[str] = None,
-        override: Optional[Type[Field]] = None,
-    ) -> UnboundField:
-        if field_args:
-            kwargs = field_args.copy()
-        else:
-            kwargs = {}
+    def convert(self, model: type, prop: T_MP, kwargs: Dict[str, Any]) -> UnboundField:
+        callback = self.get_callback(model=model, prop=prop, kwargs=kwargs)
+        return callback(model=model, prop=prop, kwargs=kwargs)
 
-        kwargs: Dict[str, Any]
-        kwargs.setdefault("label", label)
-        kwargs.setdefault("validators", [])
-        kwargs.setdefault("filters", [])
-        kwargs.setdefault("default", None)
-        kwargs.setdefault("description", prop.doc)
-        kwargs.setdefault("render_kw", {"class": "form-control"})
 
-        converter = self.get_converter(prop)
-        column = None
+def converts(*args: str) -> Callable[[T_CC], T_CC]:
+    def _inner(func: T_CC) -> T_CC:
+        func._converter_for = frozenset(args)
+        return func
 
-        if isinstance(prop, ColumnProperty):
-            assert len(prop.columns) == 1, "Multiple-column properties not supported"
-            column = prop.columns[0]
-
-            if column.primary_key or column.foreign_keys:
-                return
-
-            default = getattr(column, "default", None)
-
-            if default is not None:
-                # Only actually change default if it has an attribute named
-                # 'arg' that's callable.
-                callable_default = getattr(default, "arg", None)
-
-                if callable_default is not None:
-                    # ColumnDefault(val).arg can be also a plain value
-                    default = (
-                        callable_default(None)
-                        if callable(callable_default)
-                        else callable_default
-                    )
-
-            kwargs["default"] = default
-
-            if column.nullable:
-                kwargs["validators"].append(validators.Optional())
-            else:
-                kwargs["validators"].append(validators.InputRequired())
-        else:
-            nullable = True
-            for pair in prop.local_remote_pairs:
-                if not pair[0].nullable:
-                    nullable = False
-
-            kwargs["allow_blank"] = nullable
-
-            target_model = prop.mapper.class_
-            pk = sqlalchemy_inspect(target_model).primary_key[0].name
-            stmt = select(target_model)
-
-            if isinstance(engine, Engine):
-                with Session(engine) as session:
-                    objects = await anyio.to_thread.run_sync(session.execute, stmt)
-                    object_list = [
-                        (str(self.get_pk(obj, pk)), obj)
-                        for obj in objects.scalars().all()
-                    ]
-                    kwargs["object_list"] = object_list
-            else:
-                async with AsyncSession(engine) as session:
-                    objects = await session.execute(stmt)
-                    object_list = [
-                        (str(self.get_pk(obj, pk)), obj)
-                        for obj in objects.scalars().all()
-                    ]
-                    kwargs["object_list"] = object_list
-
-        if override is not None:
-            assert issubclass(override, Field)
-            return override(**kwargs)
-
-        return converter(
-            model=model, mapper=mapper, prop=prop, column=column, field_args=kwargs
-        )
-
-    def get_pk(self, o: Any, pk_name: str) -> Any:
-        return getattr(o, pk_name)
+    return _inner
 
 
 class ModelConverter(ModelConverterBase):
-    @classmethod
-    def _string_common(cls, column: Column, field_args: Dict, **kwargs: Any) -> None:
+    @staticmethod
+    def _string_common(prop: ColumnProperty) -> List[Validator]:
+        li = []
+        column = prop.columns[0]
         if isinstance(column.type.length, int) and column.type.length:
-            field_args["validators"].append(validators.Length(max=column.type.length))
+            li.append(validators.Length(max=column.type.length))
+        return li
 
     @converts("String")  # includes Unicode
-    def conv_String(self, field_args: Dict, **kwargs: Any) -> Field:
-        self._string_common(field_args=field_args, **kwargs)
-        return StringField(**field_args)
+    def conv_String(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        kwargs.setdefault("validators", [])
+        extra_validators = self._string_common(prop)
+        kwargs["validators"].extend(extra_validators)
+        return StringField(**kwargs)
 
     @converts("Text", "LargeBinary", "Binary")  # includes UnicodeText
-    def conv_Text(self, field_args: Dict, **kwargs: Any) -> Field:
-        self._string_common(field_args=field_args, **kwargs)
-        return TextAreaField(**field_args)
+    def conv_Text(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        kwargs.setdefault("validators", [])
+        extra_validators = self._string_common(prop)
+        kwargs["validators"].extend(extra_validators)
+        return TextAreaField(**kwargs)
 
     @converts("Boolean", "dialects.mssql.base.BIT")
-    def conv_Boolean(self, field_args: Dict, **kwargs: Any) -> Field:
-        field_args["render_kw"]["class"] = "form-check-input"
-        return BooleanField(**field_args)
+    def conv_Boolean(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        kwargs.setdefault("render_kw", {})
+        kwargs["render_kw"]["class"] = "form-check-input"
+        return BooleanField(**kwargs)
 
     @converts("Date")
-    def conv_Date(self, field_args: Dict, **kwargs: Any) -> Field:
-        return DateField(**field_args)
+    def conv_Date(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        return DateField(**kwargs)
 
     @converts("DateTime")
-    def conv_DateTime(self, field_args: Dict, **kwargs: Any) -> Field:
-        return DateTimeField(**field_args)
+    def conv_DateTime(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        return DateTimeField(**kwargs)
 
     @converts("Enum")
-    def conv_Enum(self, column: Column, field_args: Dict, **kwargs: Any) -> Field:
-        available_choices = [(e, e) for e in column.type.enums]
+    def conv_Enum(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        available_choices = [(e, e) for e in prop.columns[0].type.enums]
         accepted_values = [choice[0] for choice in available_choices]
 
-        field_args["choices"] = available_choices
-        field_args["validators"].append(validators.AnyOf(accepted_values))
-        field_args["coerce"] = lambda v: v.name if isinstance(v, Enum) else str(v)
-        return SelectField(**field_args)
+        kwargs["choices"] = available_choices
+        kwargs.setdefault("validators", [])
+        kwargs["validators"].append(validators.AnyOf(accepted_values))
+        kwargs["coerce"] = lambda v: v.name if isinstance(v, Enum) else str(v)
+        return SelectField(**kwargs)
 
     @converts("Integer")  # includes BigInteger and SmallInteger
     def handle_integer_types(
-        self, column: Column, field_args: Dict, **kwargs: Any
-    ) -> Field:
-        return IntegerField(**field_args)
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        return IntegerField(**kwargs)
 
     @converts("Numeric")  # includes DECIMAL, Float/FLOAT, REAL, and DOUBLE
     def handle_decimal_types(
-        self, column: Column, field_args: Dict, **kwargs: Any
-    ) -> Field:
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
         # override default decimal places limit, use database defaults instead
-        field_args.setdefault("places", None)
-        return DecimalField(**field_args)
+        kwargs.setdefault("places", None)
+        return DecimalField(**kwargs)
 
     # @converts("dialects.mysql.types.YEAR", "dialects.mysql.base.YEAR")
-    # def conv_MSYear(self, field_args: Dict, **kwargs: Any) -> Field:
-    #     field_args["validators"].append(validators.NumberRange(min=1901, max=2155))
-    #     return StringField(**field_args)
+    # def conv_MSYear(
+    #         self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    # ) -> UnboundField:
+    #     kwargs.setdefault("validators", [])
+    #     kwargs["validators"].append(validators.NumberRange(min=1901, max=2155))
+    #     return StringField(**kwargs)
 
     @converts("sqlalchemy.dialects.postgresql.base.INET")
-    def conv_PGInet(self, field_args: Dict, **kwargs: Any) -> Field:
-        field_args.setdefault("label", "IP Address")
-        field_args["validators"].append(validators.IPAddress())
-        return StringField(**field_args)
+    def conv_PGInet(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        kwargs.setdefault("label", "IP Address")
+        kwargs.setdefault("validators", [])
+        kwargs["validators"].append(validators.IPAddress())
+        return StringField(**kwargs)
 
     @converts("sqlalchemy.dialects.postgresql.base.MACADDR")
-    def conv_PGMacaddr(self, field_args: Dict, **kwargs: Any) -> Field:
-        field_args.setdefault("label", "MAC Address")
-        field_args["validators"].append(validators.MacAddress())
-        return StringField(**field_args)
+    def conv_PGMacaddr(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        kwargs.setdefault("label", "MAC Address")
+        kwargs.setdefault("validators", [])
+        kwargs["validators"].append(validators.MacAddress())
+        return StringField(**kwargs)
 
     @converts("sqlalchemy.dialects.postgresql.base.UUID")
-    def conv_PgUuid(self, field_args: Dict, **kwargs: Any) -> Field:
-        field_args.setdefault("label", "UUID")
-        field_args["validators"].append(validators.UUID())
-        return StringField(**field_args)
+    def conv_PgUuid(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        kwargs.setdefault("label", "UUID")
+        kwargs.setdefault("validators", [])
+        kwargs["validators"].append(validators.UUID())
+        return StringField(**kwargs)
 
     @converts("JSON")
-    def convert_JSON(self, field_args: dict, **extra: Any) -> Field:
-        return JSONField(**field_args)
+    def convert_JSON(
+        self, model: type, prop: ColumnProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        return JSONField(**kwargs)
 
     @converts("MANYTOONE")
-    def conv_ManyToOne(self, field_args: Dict, **kwargs: Any) -> Field:
-        return QuerySelectField(**field_args)
+    def conv_ManyToOne(
+        self, model: type, prop: RelationshipProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        return QuerySelectField(**kwargs)
 
     @converts("MANYTOMANY", "ONETOMANY")
-    def conv_ManyToMany(self, field_args: Dict, **kwargs: Any) -> Field:
-        return QuerySelectMultipleField(**field_args)
+    def conv_ManyToMany(
+        self, model: type, prop: RelationshipProperty, kwargs: Dict[str, Any]
+    ) -> UnboundField:
+        return QuerySelectMultipleField(**kwargs)
 
 
 async def get_model_form(
@@ -272,32 +377,53 @@ async def get_model_form(
     form_args: Dict[str, Dict[str, Any]] = None,
     form_class: Type[Form] = Form,
     form_overrides: Dict[str, Dict[str, Type[Field]]] = None,
+    converter_class: Type[ModelConverterBase] = ModelConverter,
 ) -> Type[Form]:
     type_name = model.__name__ + "Form"
-    converter = ModelConverter()
+    converter = converter_class()
     mapper = sqlalchemy_inspect(model)
     form_args = form_args or {}
     column_labels = column_labels or {}
     form_overrides = form_overrides or {}
 
-    attributes = []
-    for name, attr in mapper.attrs.items():
+    admin_attrs = []
+
+    for name, prop in mapper.attrs.items():
         if only and name not in only:
             continue
         elif exclude and name in exclude:
             continue
 
-        attributes.append((name, attr))
-
-    field_dict = {}
-    for name, attr in attributes:
-        field_args = form_args.get(name, {})
-        label = column_labels.get(name, None)
-        override = form_overrides.get(name, None)
-        field = await converter.convert(
-            model, mapper, attr, engine, field_args, label, override
+        attr = AdminAttribute(
+            model=model,
+            attribute=name,
+            label=column_labels.get(name),
+            field_type_override=form_overrides.get(name),
+            extra_field_kwargs=form_args.get(name),
         )
+
+        if attr.skip():
+            continue
+
+        admin_attrs.append(attr)
+
+    field_dict: Dict[str, UnboundField] = {}
+
+    for attr in admin_attrs:
+        kwargs = attr.field_kwargs
+
+        if attr.is_relationship:
+            kwargs["object_list"] = await attr.get_object_list(engine=engine)
+
+        if attr.field_type_override is not None:
+            field = attr.field_type_override(**kwargs)
+
+        else:
+            field = converter.convert(
+                model=attr.model, prop=attr.sqla_property, kwargs=kwargs
+            )
+
         if field is not None:
-            field_dict[name] = field
+            field_dict[attr.sqla_property.key] = field
 
     return type(type_name, (form_class,), field_dict)

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -38,15 +38,15 @@ T_MP = TypeVar("T_MP", ColumnProperty, RelationshipProperty)
 
 class Validator(Protocol):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        ...
+        ...  # pragma: no cover
 
     def __call__(self, form: Form, field: Field) -> None:
-        ...
+        ...  # pragma: no cover
 
 
 class ConverterCallback(Protocol):
     def __call__(self, model: type, prop: T_MP, kwargs: Dict[str, Any]) -> UnboundField:
-        ...
+        ...  # pragma: no cover
 
 
 T_CC = TypeVar("T_CC", bound=ConverterCallback)
@@ -82,7 +82,7 @@ class AdminAttribute:
         if self.is_relationship:
             return False
         else:
-            return bool(self.sqla_column.primary_key or self.sqla_column.foreign_keys)
+            return bool(self.column.primary_key or self.column.foreign_keys)
 
     @property
     def is_relationship(self) -> bool:
@@ -93,7 +93,7 @@ class AdminAttribute:
         return self.attribute.prop
 
     @property
-    def sqla_column(self) -> Column:
+    def column(self) -> Column:
         assert isinstance(
             self.sqla_property, ColumnProperty
         ), "Relationship properties don't have a column attr"
@@ -107,7 +107,7 @@ class AdminAttribute:
         if self.is_relationship:
             return None
 
-        default = getattr(self.sqla_column, "default", None)
+        default = getattr(self.column, "default", None)
 
         if default is not None:
             # Only actually change default if it has an attribute named
@@ -129,7 +129,7 @@ class AdminAttribute:
         if self.is_relationship:
             return []
         li = []
-        if self.sqla_column.nullable:
+        if self.column.nullable:
             li.append(validators.Optional())
         else:
             li.append(validators.InputRequired())


### PR DESCRIPTION
## Objectives

This PR is a refactor of `forms.py`.

The immediate objectives of this refactor are listed in the section titled "Code Changes".

The longer-term objective of this refactor is to move toward using `AdminAttribute`s internally. A lot of the code right now is hard to manage because there is no concept that relates a single SQLA/wtforms field/column/property. Ultimately, a `List[AdminAttribute]` should be generated by the `ModelAdmin()` instance, instead of inside `get_model_form()`.

In my opinion, more and more parsing/app logic should move toward `AdminAttribute` internals, and then the rest of the code can focus more on the core framework logic. Right now, a lot of parsing, and generation of defaults, is being handled at multiple parts of the code. `AdminAttribute` can be a single spot for all the "ugly but necessary" stuff, and the rest of the code (the parts we want to actually add features) will be cleaner as a result.

## Code Changes

### Consistent typing:

- Create a `ConverterCallback` type with a sensible signature. (In this case, pulled from Flask-Admin's pattern.)
- Apply the signature to decorated `@converts(...)` methods.
- wtforms has very weird typing (or rather, a lack of typing). I added a type for the wtforms validators. I got the type right (check `wtforms/validators.py`), but it's unclear whether this is appropriate.

### Renames

#### Converter Callbacks

The main purpose of the renaming in this refactor is to enforce the distinction between a **converter** and a **converter callback**. The class is called `ModelConverter`, which implies that a `ModelConverter()` object is the _converter_. But, in the code, `get_converter()` does not get a converter instance, it gets a callable that is not a converter _per se_ (based on the convention that a `ModelConverter` is a converter.

To have consistent naming, the function should be called a "converter callback," to distinguish it from the converter class. All references to the decorated functions should then make clear that these are "converter callbacks" and not mere "converters."

- `ModelConverterBase.get_converter()` --> `ModelConverterBase.get_callback()`
- `ModelConverterBase.converters` --> `ModelConverterBase._callbacks`
- Create a type called `ConverterCallback` to reinforce both the concept and the signature.

#### Property vs attribute

`mapper.attrs` misleadingly returns objects of type `Union[ColumnProperty, RelationshipProperty]`. I think we should move toward referring to objects with this typing as `prop`s. In the function `get_model_form`, I adhere to this behavior. (Although I don't make any additional changes in the rest of the code.)