### PR TITLE
Fix get_model_attr with column labels

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -423,6 +423,9 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
 
     def __init__(self) -> None:
         self._column_labels = self.get_column_labels()
+        self._column_labels_value_by_key = {
+            v: k for k, v in self._column_labels.items()
+        }
 
         self._list_attrs = self.get_list_columns()
         self._list_columns = [
@@ -593,12 +596,16 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
         elif isinstance(attr.prop, RelationshipProperty):
             key = attr.prop.key
 
-        try:
+        if key in inspect(self.model).attrs:
             return inspect(self.model).attrs[key]
-        except KeyError:
-            raise InvalidColumnError(
-                f"Model '{self.model.__name__}' has no attribute '{key}'."
-            )
+
+        # Get value by column label
+        if key in self._column_labels_value_by_key:
+            return self._column_labels_value_by_key[key]
+
+        raise InvalidColumnError(
+            f"Model '{self.model.__name__}' has no attribute '{key}'."
+        )
 
     def get_model_attributes(self) -> List[Column]:
         return list(inspect(self.model).attrs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -213,7 +213,7 @@ def test_column_labels_by_model_columns() -> None:
     assert AddressAdmin().get_details_columns() == [("User ID", Address.user_id)]
 
 
-def test_get_model_attr_with_column_labels() -> None:
+def test_get_model_attr_by_column() -> None:
     class UserAdmin(ModelAdmin, model=User):
         ...
 
@@ -221,7 +221,7 @@ def test_get_model_attr_with_column_labels() -> None:
     assert UserAdmin().get_model_attr(User.name) == User.name
 
 
-def test_get_model_attr_with_column_labels() -> None:
+def test_get_model_attr_by_column_labels() -> None:
     class UserAdmin(ModelAdmin, model=User):
         column_labels = {User.name: "Name"}
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -213,6 +213,23 @@ def test_column_labels_by_model_columns() -> None:
     assert AddressAdmin().get_details_columns() == [("User ID", Address.user_id)]
 
 
+def test_get_model_attr_with_column_labels() -> None:
+    class UserAdmin(ModelAdmin, model=User):
+        ...
+
+    assert UserAdmin().get_model_attr("name") == User.name
+    assert UserAdmin().get_model_attr(User.name) == User.name
+
+
+def test_get_model_attr_with_column_labels() -> None:
+    class UserAdmin(ModelAdmin, model=User):
+        column_labels = {User.name: "Name"}
+
+    assert UserAdmin().get_model_attr("Name") == User.name
+    assert UserAdmin().get_model_attr("name") == User.name
+    assert UserAdmin().get_model_attr(User.name) == User.name
+
+
 def test_form_columns_default() -> None:
     class UserAdmin(ModelAdmin, model=User):
         pass


### PR DESCRIPTION
Fixes #118 .

Getting model attributes should work both with column names or column labels. The priority is with the column though.