### PR TITLE
Delay call to `self.get_converter`

### DIFF
--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -102,7 +102,6 @@ class ModelConverterBase:
         kwargs.setdefault("description", prop.doc)
         kwargs.setdefault("render_kw", {"class": "form-control"})
 
-        converter = self.get_converter(prop)
         column = None
 
         if isinstance(prop, ColumnProperty):
@@ -166,6 +165,8 @@ class ModelConverterBase:
             assert issubclass(override, Field)
             return override(**kwargs)
 
+        converter = self.get_converter(prop)
+        
         return converter(
             model=model, mapper=mapper, prop=prop, column=column, field_args=kwargs
         )

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -166,7 +166,7 @@ class ModelConverterBase:
             return override(**kwargs)
 
         converter = self.get_converter(prop)
-        
+
         return converter(
             model=model, mapper=mapper, prop=prop, column=column, field_args=kwargs
         )


### PR DESCRIPTION
- This enables users who pass in `form_overrides` to bypass `self.get_converter()`, which can still break on custom/unsupported types (eg `sqlalchemy_utils.types.ChoiceType`)