### PR TITLE
docs: fix typos

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -186,7 +186,7 @@ The export options can be set per model and includes the following options:
 
 ## Templates
 
-The template files are built using Jinja2 and can be completely overriden in the configurations.
+The template files are built using Jinja2 and can be completely overridden in the configurations.
 The pages available are:
 
 * `list_template`: Template to use for models list page. Default is `list.html`.

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -237,7 +237,7 @@ class Admin(BaseAdminView):
         self.app.mount(base_url, app=admin, name="admin")
 
     async def index(self, request: Request) -> Response:
-        """Index route which can be overriden to create dashboards."""
+        """Index route which can be overridden to create dashboards."""
 
         return self.templates.TemplateResponse("index.html", {"request": request})
 


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `docs/configurations.md`
- 1 typo in `sqladmin/application.py`



Bye! :robot: