### PR TITLE
Fix HTML required flag

### DIFF
--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 import anyio
-from sqlalchemy import inspect as sqlalchemy_inspect, select
+from sqlalchemy import Boolean, inspect as sqlalchemy_inspect, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import ColumnProperty, RelationshipProperty, Session
@@ -133,10 +133,17 @@ class ModelConverterBase:
                     )
 
             kwargs["default"] = default
+            optional_types = (Boolean,)
 
             if column.nullable:
                 kwargs["validators"].append(validators.Optional())
-            else:
+
+            if (
+                not column.nullable
+                and not isinstance(column.type, optional_types)
+                and not column.default
+                and not column.server_default
+            ):
                 kwargs["validators"].append(validators.InputRequired())
         else:
             nullable = True

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -94,7 +94,12 @@ async def prepare_database() -> AsyncGenerator[None, None]:
 
 async def test_model_form() -> None:
     Form = await get_model_form(model=User, engine=engine)
-    assert len(Form()._fields) == 10
+    form = Form()
+
+    assert len(form._fields) == 10
+    assert form._fields["active"].flags.required is None
+    assert form._fields["name"].flags.required is None
+    assert form._fields["email"].flags.required is True
 
 
 async def test_model_form_converter_with_default() -> None:


### PR DESCRIPTION
This fixes the HTML required flag being present at all times and should not be required for some cases like Booleans or fields having default or server_default values.

Fixes #194 