### PR TITLE
Use zip for iterating over the formatted values

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -52,6 +52,7 @@ class BaseAdmin:
             ]
         )
         self.templates.env.globals["min"] = min
+        self.templates.env.globals["zip"] = zip
         self.templates.env.globals["admin_title"] = title
         self.templates.env.globals["admin_logo_url"] = logo_url
         self.templates.env.globals["model_admins"] = self.model_admins

--- a/sqladmin/templates/details.html
+++ b/sqladmin/templates/details.html
@@ -22,8 +22,8 @@
               {% if (name, attr) in model_admin._details_relations %}
               {% if is_iterable( value ) %}
               <td>
-              {% for elem in value %}
-              <a href="{{ model_admin._url_for_details(elem) }}">({{ formatted_value[loop.index0] }})</a>
+              {% for elem, formatted_elem in zip(value, formatted_value) %}
+              <a href="{{ model_admin._url_for_details(elem) }}">({{ formatted_elem }})</a>
               {% endfor %}
               </td>
               {% else %}

--- a/sqladmin/templates/list.html
+++ b/sqladmin/templates/list.html
@@ -110,8 +110,8 @@
             {% if (name, column) in model_admin._list_relations %}
             {% if is_iterable( value ) %}
             <td>
-            {% for elem in value %}
-            <a href="{{ model_admin._url_for_details(elem) }}">({{ formatted_value[loop.index0] }})</a>
+            {% for elem, formatted_elem in zip(value, formatted_value) %}
+            <a href="{{ model_admin._url_for_details(elem) }}">({{ formatted_elem }})</a>
             {% endfor %}
             </td>
             {% else %}


### PR DESCRIPTION
Fix to use `zip` for iterating over the formatted values. It prevents retrieving `formatted_value` by index especially when it is `Iterable` but not `Sequence`.

Ref. #204.