### PR TITLE
Add form_include_pk option

### DIFF
--- a/docs/api_reference/model_admin.md
+++ b/docs/api_reference/model_admin.md
@@ -40,3 +40,4 @@
         - form_excluded_columns
         - form_overrides
         - form_widget_args
+        - form_include_pk

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -179,6 +179,7 @@ The forms are based on `WTForms` package and include the following options:
 * `form_columns`: List of model columns to be included in the form. Default is all model columns.
 * `form_excluded_columns`: List of model columns to be excluded from the form.
 * `form_overrides`: Dictionary of form fields to override when creating the form.
+* `form_include_pk`: Control if primary key column should be included in create/edit forms. Default is `False`.
 
 !!! example
 
@@ -188,6 +189,7 @@ The forms are based on `WTForms` package and include the following options:
         form_args = dict(name=dict(label="Full name"))
         form_widget_args = dict(email=dict(readonly=True))
         form_overrides = dict(email=wtforms.EmailField)
+        form_include_pk = True
     ```
 
 ## Export options

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -13,8 +13,6 @@ from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
-from sqladmin.helpers import is_iterable
-
 if TYPE_CHECKING:
     from sqladmin.models import ModelAdmin
 
@@ -56,7 +54,7 @@ class BaseAdmin:
         self.templates.env.globals["admin_title"] = title
         self.templates.env.globals["admin_logo_url"] = logo_url
         self.templates.env.globals["model_admins"] = self.model_admins
-        self.templates.env.globals["is_iterable"] = is_iterable
+        self.templates.env.globals["is_list"] = lambda x: isinstance(x, list)
 
     @property
     def model_admins(self) -> List["ModelAdmin"]:

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -99,6 +99,7 @@ class ModelConverterBase:
         engine: Union[Engine, AsyncEngine],
         field_args: Dict[str, Any],
         field_widget_args: Dict[str, Any],
+        form_include_pk: bool,
         label: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         kwargs = field_args.copy()
@@ -118,7 +119,7 @@ class ModelConverterBase:
             assert len(prop.columns) == 1, "Multiple-column properties not supported"
             column = prop.columns[0]
 
-            if column.primary_key or column.foreign_keys:
+            if (column.primary_key or column.foreign_keys) and not form_include_pk:
                 return None
 
             default = getattr(column, "default", None)
@@ -231,6 +232,7 @@ class ModelConverterBase:
         engine: Union[Engine, AsyncEngine],
         field_args: Dict[str, Any],
         field_widget_args: Dict[str, Any],
+        form_include_pk: bool,
         label: Optional[str] = None,
         override: Optional[Type[Field]] = None,
     ) -> Optional[UnboundField]:
@@ -241,6 +243,7 @@ class ModelConverterBase:
             field_args=field_args,
             field_widget_args=field_widget_args,
             label=label,
+            form_include_pk=form_include_pk,
         )
 
         if kwargs is None:
@@ -441,6 +444,7 @@ async def get_model_form(
     form_widget_args: Dict[str, Dict[str, Any]] = None,
     form_class: Type[Form] = Form,
     form_overrides: Dict[str, Dict[str, Type[Field]]] = None,
+    form_include_pk: bool = False,
 ) -> Type[Form]:
     type_name = model.__name__ + "Form"
     converter = ModelConverter()
@@ -471,6 +475,7 @@ async def get_model_form(
             field_widget_args=field_widget_args,
             label=label,
             override=override,
+            form_include_pk=form_include_pk,
         )
         if field is not None:
             field_dict[name] = field

--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -3,8 +3,7 @@ import os
 import re
 import unicodedata
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from typing import Any, Callable, Generator, List, TypeVar, Union
+from typing import Callable, Generator, List, TypeVar, Union
 
 T = TypeVar("T")
 
@@ -23,10 +22,6 @@ _windows_device_files = (
     "PRN",
     "NUL",
 )
-
-
-def is_iterable(obj: Any) -> bool:
-    return isinstance(obj, Iterable) and not isinstance(obj, (str, bytes))
 
 
 def as_str(s: Union[str, bytes]) -> str:

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -508,6 +508,16 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
         ```
     """
 
+    form_include_pk: ClassVar[bool] = False
+    """Control if form should include primary key columns or not.
+
+    ???+ example
+        ```python
+        class UserAdmin(ModelAdmin, model=User):
+            form_include_pk = True
+        ```
+    """
+
     def __init__(self) -> None:
         self._column_labels = self.get_column_labels()
         self._column_labels_value_by_key = {
@@ -905,6 +915,7 @@ class ModelAdmin(BaseModelAdmin, metaclass=ModelAdminMeta):
             form_widget_args=self.form_widget_args,
             form_class=self.form_base_class,
             form_overrides=self.form_overrides,
+            form_include_pk=self.form_include_pk,
         )
 
     def search_placeholder(self) -> str:

--- a/sqladmin/templates/details.html
+++ b/sqladmin/templates/details.html
@@ -20,7 +20,7 @@
               <td>{{ name }}</td>
               {% set value, formatted_value = model_admin.get_detail_value(model, attr) %}
               {% if (name, attr) in model_admin._details_relations %}
-              {% if is_iterable( value ) %}
+              {% if is_list( value ) %}
               <td>
               {% for elem, formatted_elem in zip(value, formatted_value) %}
               <a href="{{ model_admin._url_for_details(elem) }}">({{ formatted_elem }})</a>

--- a/sqladmin/templates/list.html
+++ b/sqladmin/templates/list.html
@@ -108,7 +108,7 @@
             {% for name, column in model_admin._list_attrs %}
             {% set value, formatted_value = model_admin.get_list_value(row, column) %}
             {% if (name, column) in model_admin._list_relations %}
-            {% if is_iterable( value ) %}
+            {% if is_list( value ) %}
             <td>
             {% for elem, formatted_elem in zip(value, formatted_value) %}
             <a href="{{ model_admin._url_for_details(elem) }}">({{ formatted_elem }})</a>

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -238,3 +238,8 @@ async def test_form_converter_when_impl_not_callable() -> None:
 
     Form = await get_model_form(model=CustomModel, engine=engine)
     assert "custom" in Form()._fields
+
+
+async def test_model_form_include_pk() -> None:
+    Form = await get_model_form(model=User, engine=engine, form_include_pk=True)
+    assert "id" in Form()._fields


### PR DESCRIPTION
Fixes #200 gives the option to include PK in create/edit forms.

Before you had to do this:

```python
class UserAdmin(ModelAdmin, model=User):
    form_columns = [User.id, ....]
```

Now if you don't want to edit form_columns you can do:

```python
class UserAdmin(ModelAdmin, model=User):
    form_include_pk = True
```