### PR TITLE
Fix missing browser tab title

### DIFF
--- a/sqladmin/templates/base.html
+++ b/sqladmin/templates/base.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{{ url_for('admin:statics', path='css/main.css') }}">
     {% block head %}
     {% endblock %}
-    <title>{{ title }}</title>
+    <title>{{ admin_title }}</title>
   </head>
   <body>
     {% block body %}

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -25,6 +25,7 @@ def test_application_title() -> None:
 
     assert response.status_code == 200
     assert response.text.count("<h3>Admin</h3>") == 1
+    assert response.text.count("<title>Admin</title>") == 1
 
 
 def test_application_logo() -> None:


### PR DESCRIPTION
`<title>` tag wasn't set propperly in `<head>` of html, so I fixed it