### PR TITLE
Add `expose` for BaseView

### DIFF
--- a/sqladmin/__init__.py
+++ b/sqladmin/__init__.py
@@ -1,10 +1,12 @@
-from sqladmin.application import Admin
-from sqladmin.models import ModelAdmin, ModelView
+from sqladmin.application import Admin, expose
+from sqladmin.models import BaseView, ModelAdmin, ModelView
 
 __version__ = "0.1.12"
 
 __all__ = [
     "Admin",
+    "expose",
+    "BaseView",
     "ModelAdmin",
     "ModelView",
 ]

--- a/sqladmin/_queries.py
+++ b/sqladmin/_queries.py
@@ -4,14 +4,14 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import Select
 
+from sqladmin._types import MODEL_ATTR_TYPE
 from sqladmin.helpers import get_column_python_type, get_direction, get_primary_key
-from sqladmin.types import _MODEL_ATTR_TYPE
 
 if TYPE_CHECKING:
     from sqladmin.models import ModelView
 
 
-def _get_to_many_stmt(relation: _MODEL_ATTR_TYPE, values: List[Any]) -> Select:
+def _get_to_many_stmt(relation: MODEL_ATTR_TYPE, values: List[Any]) -> Select:
     target = relation.mapper.class_
     target_pk = get_primary_key(target)
     target_pk_type = get_column_python_type(target_pk)
@@ -20,7 +20,7 @@ def _get_to_many_stmt(relation: _MODEL_ATTR_TYPE, values: List[Any]) -> Select:
     return related_stmt
 
 
-def _get_to_one_stmt(relation: _MODEL_ATTR_TYPE, value: Any) -> Select:
+def _get_to_one_stmt(relation: MODEL_ATTR_TYPE, value: Any) -> Select:
     target = relation.mapper.class_
     target_pk = get_primary_key(target)
     target_pk_type = get_column_python_type(target_pk)

--- a/sqladmin/_types.py
+++ b/sqladmin/_types.py
@@ -3,5 +3,5 @@ from typing import Union
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import ColumnProperty, RelationshipProperty, Session
 
-_MODEL_ATTR_TYPE = Union[ColumnProperty, RelationshipProperty]
-_ENGINE_TYPE = Union[Session, AsyncSession]
+MODEL_ATTR_TYPE = Union[ColumnProperty, RelationshipProperty]
+ENGINE_TYPE = Union[Session, AsyncSession]

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -13,8 +13,8 @@ from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
+from sqladmin._types import ENGINE_TYPE
 from sqladmin.models import BaseView, ModelView
-from sqladmin.types import _ENGINE_TYPE
 
 __all__ = [
     "Admin",
@@ -31,7 +31,7 @@ class BaseAdmin:
     def __init__(
         self,
         app: Starlette,
-        engine: _ENGINE_TYPE,
+        engine: ENGINE_TYPE,
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str = None,
@@ -83,7 +83,7 @@ class BaseAdmin:
 
     def add_view(self, view: Union[Type[ModelView], Type[BaseView]]) -> None:
         """Add ModelView or BaseView classes to Admin."""
-        if ModelView in view.__bases__:
+        if view.is_model:
             self.add_model_view(view)  # type: ignore
         else:
             self.add_base_view(view)
@@ -236,7 +236,7 @@ class Admin(BaseAdminView):
     def __init__(
         self,
         app: Starlette,
-        engine: _ENGINE_TYPE,
+        engine: ENGINE_TYPE,
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str = None,

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -36,6 +36,7 @@ from wtforms import (
 )
 from wtforms.fields.core import UnboundField
 
+from sqladmin._types import ENGINE_TYPE, MODEL_ATTR_TYPE
 from sqladmin._validators import CurrencyValidator, TimezoneValidator
 from sqladmin.exceptions import NoConverterFound
 from sqladmin.fields import (
@@ -45,7 +46,6 @@ from sqladmin.fields import (
     SelectField,
 )
 from sqladmin.helpers import get_direction, get_primary_key
-from sqladmin.types import _ENGINE_TYPE, _MODEL_ATTR_TYPE
 
 
 class Validator(Protocol):
@@ -60,7 +60,7 @@ class ConverterCallable(Protocol):
     def __call__(
         self,
         model: type,
-        prop: _MODEL_ATTR_TYPE,
+        prop: MODEL_ATTR_TYPE,
         kwargs: Dict[str, Any],
     ) -> UnboundField:
         ...  # pragma: no cover
@@ -98,8 +98,8 @@ class ModelConverterBase:
 
     async def _prepare_kwargs(
         self,
-        prop: _MODEL_ATTR_TYPE,
-        engine: _ENGINE_TYPE,
+        prop: MODEL_ATTR_TYPE,
+        engine: ENGINE_TYPE,
         field_args: Dict[str, Any],
         field_widget_args: Dict[str, Any],
         form_include_pk: bool,
@@ -169,7 +169,7 @@ class ModelConverterBase:
         return kwargs
 
     async def _prepare_relationship(
-        self, prop: RelationshipProperty, kwargs: dict, engine: _ENGINE_TYPE
+        self, prop: RelationshipProperty, kwargs: dict, engine: ENGINE_TYPE
     ) -> dict:
         nullable = True
         for pair in prop.local_remote_pairs:
@@ -184,7 +184,7 @@ class ModelConverterBase:
     async def _prepare_select_options(
         self,
         prop: RelationshipProperty,
-        engine: _ENGINE_TYPE,
+        engine: ENGINE_TYPE,
     ) -> List[Tuple[str, Any]]:
         target_model = prop.mapper.class_
         pk = get_primary_key(target_model)
@@ -207,7 +207,7 @@ class ModelConverterBase:
 
         return []  # pragma: nocover
 
-    def get_converter(self, prop: _MODEL_ATTR_TYPE) -> ConverterCallable:
+    def get_converter(self, prop: MODEL_ATTR_TYPE) -> ConverterCallable:
         if isinstance(prop, RelationshipProperty):
             direction = get_direction(prop)
             return self._converters[direction]
@@ -244,8 +244,8 @@ class ModelConverterBase:
     async def convert(
         self,
         model: type,
-        prop: _MODEL_ATTR_TYPE,
-        engine: _ENGINE_TYPE,
+        prop: MODEL_ATTR_TYPE,
+        engine: ENGINE_TYPE,
         field_args: Dict[str, Any],
         field_widget_args: Dict[str, Any],
         form_include_pk: bool,
@@ -464,7 +464,7 @@ class ModelConverter(ModelConverterBase):
 
 async def get_model_form(
     model: type,
-    engine: _ENGINE_TYPE,
+    engine: ENGINE_TYPE,
     only: Sequence[str] = None,
     exclude: Sequence[str] = None,
     column_labels: Dict[str, str] = None,

--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Generator, List, TypeVar, Union
 from sqlalchemy import Column, inspect
 from sqlalchemy.orm import RelationshipProperty
 
-from sqladmin.types import _MODEL_ATTR_TYPE
+from sqladmin._types import MODEL_ATTR_TYPE
 
 T = TypeVar("T")
 
@@ -126,15 +126,15 @@ def get_primary_key(model: type) -> Column:
     return pks[0]
 
 
-def get_relationships(model: Any) -> List[_MODEL_ATTR_TYPE]:
+def get_relationships(model: Any) -> List[MODEL_ATTR_TYPE]:
     return list(inspect(model).relationships)
 
 
-def get_attributes(model: Any) -> List[_MODEL_ATTR_TYPE]:
+def get_attributes(model: Any) -> List[MODEL_ATTR_TYPE]:
     return list(inspect(model).attrs)
 
 
-def get_direction(attr: _MODEL_ATTR_TYPE) -> str:
+def get_direction(attr: MODEL_ATTR_TYPE) -> str:
     assert isinstance(attr, RelationshipProperty)
     name = attr.direction.name
     if name == "ONETOMANY" and not attr.uselist:

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -137,19 +137,54 @@ class BaseModelView:
 
 
 class BaseView(BaseModelView):
+    """Base class for defining admnistrative views for the model.
+
+    ???+ usage
+        ```python
+        from sqladmin import BaseView, expose
+
+        class CustomAdmin(BaseView):
+            name = "Custom Page"
+            icon = "fa-solid fa-chart-line"
+
+            @expose("/custom", methods=["GET"])
+            def test_page(self, request: Request):
+                return self.templates.TemplateResponse(
+                    "custom.html",
+                    context={"request": request},
+                )
+
+        admin.add_base_view(CustomAdmin)
+        ```
+    """
+
+    # Internals
     is_model: ClassVar[bool] = False
-    methods: ClassVar[List[str]] = ["GET"]
-    include_in_schema: ClassVar[bool] = True
-
-    name: ClassVar[str]
-    name_plural: ClassVar[str]
-
-    icon: ClassVar[str]
-    path: ClassVar[str]
-
-    endpoint: ClassVar[Callable]
     url_path_for: ClassVar[Callable]
     templates: ClassVar[Jinja2Templates]
+
+    name: ClassVar[str]
+    """Name of the view to be displayed."""
+
+    identity: ClassVar[str]
+    """Plural name of ModelView.
+    Default value is Model class name + `s`.
+    """
+
+    methods: ClassVar[List[str]] = ["GET"]
+    """List of method names for the endpoint.
+    By default it's set to `["GET"]` only.
+    """
+
+    include_in_schema: ClassVar[bool] = True
+    """Control whether this endpoint
+    should be included in the schema.
+    """
+
+    icon: ClassVar[str]
+    """Display icon for ModelAdmin in the sidebar.
+    Currently only supports FontAwesome icons.
+    """
 
 
 class ModelView(BaseView, metaclass=ModelViewMeta):
@@ -170,7 +205,6 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
 
     # Internals
     pk_column: ClassVar[Column]
-    identity: ClassVar[str]
     sessionmaker: ClassVar[sessionmaker]
     engine: ClassVar[ENGINE_TYPE]
     async_engine: ClassVar[bool]

--- a/sqladmin/templates/layout.html
+++ b/sqladmin/templates/layout.html
@@ -20,12 +20,12 @@
             {% if view.is_model %}
             <a class="nav-link {% if view.identity == request.path_params['identity'] %}active{% endif %}" href="{{ url_for('admin:list', identity=view.identity) }}">
             {% else %}
-            <a class="nav-link {% if view.identity == request.path_params['identity'] %}active{% endif %}" href="{{  view.url_path_for(view.name_plural) }}">
+            <a class="nav-link {% if view.identity == request.path_params['identity'] %}active{% endif %}" href="{{ url_for('admin:%s' | format(view.identity)) }}">
             {% endif %}
             <span class="nav-link-icon d-md-none d-lg-inline-block">
             {% if view.icon %} <i class="{{ view.icon }}"></i> {% endif %}
             </span>
-            <span class="nav-link-title">{{ view.name_plural }}</span>
+            <span class="nav-link-title">{{ view.name_plural or view.name }}</span>
             </a>
           </li>
           {% endif %}

--- a/tests/test_base_view.py
+++ b/tests/test_base_view.py
@@ -7,8 +7,7 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.testclient import TestClient
 
-from sqladmin import Admin
-from sqladmin.models import BaseView
+from sqladmin import Admin, BaseView, expose
 from tests.common import sync_engine as engine
 
 Base = declarative_base()  # type: Any
@@ -20,16 +19,20 @@ admin = Admin(app=app, engine=engine, templates_dir="tests/templates")
 
 
 class CustomAdmin(BaseView):
-    def test_page(self, request: Request):
+    name = "test"
+    icon = "fa fa-test"
+
+    @expose("/custom", methods=["GET"])
+    def custom(self, request: Request):
         return self.templates.TemplateResponse(
             "custom.html", context={"request": request}
         )
 
-    name_plural = "Test me"
-    icon = "fa-user"
-    path = "/custom/test_page"
-    methods = ["GET"]
-    endpoint = test_page
+    @expose("/custom/report")
+    def custom_report(self, request: Request):
+        return self.templates.TemplateResponse(
+            "custom.html", context={"request": request}
+        )
 
 
 @pytest.fixture
@@ -41,10 +44,13 @@ def client() -> Generator[TestClient, None, None]:
 def test_base_view(client: TestClient) -> None:
     admin.add_view(CustomAdmin)
 
-    url = CustomAdmin().url_path_for(CustomAdmin.name_plural)
-    assert url == "/custom/test_page"
+    url = CustomAdmin().url_path_for("admin:custom")
+    assert url == "/admin/custom"
 
-    response = client.get("/custom/test_page")
+    response = client.get("/admin/custom")
 
     assert response.status_code == 200
     assert response.text.count("<p>Here I'm going to display some data.</p>") == 1
+
+    response = client.get("/admin/custom/report")
+    assert response.status_code == 200


### PR DESCRIPTION
Adds `expose` method to be used for `BaseView` like:

```python
class CustomAdmin(BaseView):
    name = "test"
    icon = "fa fa-test"

    @expose("/custom", methods=["GET"])
    def custom(self, request: Request):
        return self.templates.TemplateResponse(
            "custom.html", context={"request": request}
        )

    @expose("/custom/report")
    def custom_report(self, request: Request):
        return self.templates.TemplateResponse(
            "custom.html", context={"request": request}
        )
```