### PR TITLE
Add typing_extensions to requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ zip_safe = False
 python_requires = >=3.7
 install_requires =
     starlette
-    typing_extensions>=4.0;python_version < '3.8',
+    typing_extensions>=4.0;python_version < '3.8'
     jinja2
     sqlalchemy >=1.4, <1.5
     wtforms >=3, <4

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ zip_safe = False
 python_requires = >=3.7
 install_requires =
     starlette
+    typing_extensions>=4.0;python_version < '3.8',
     jinja2
     sqlalchemy >=1.4, <1.5
     wtforms >=3, <4

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 from enum import Enum
 from typing import (
     Any,
@@ -20,7 +21,6 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import ColumnProperty, RelationshipProperty, Session
 from sqlalchemy.sql.schema import Column
-from typing_extensions import Protocol
 from wtforms import (
     BooleanField,
     DateField,
@@ -46,6 +46,11 @@ from sqladmin.fields import (
     SelectField,
 )
 from sqladmin.helpers import get_direction, get_primary_key
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 
 class Validator(Protocol):


### PR DESCRIPTION
Required for Python 3.7 and in some rare case of a specific driver can be uninstalled. This makes sure this won't happen.