### PR TITLE
fix `middlewares` and `ENGINE_TYPE` types

### DIFF
--- a/sqladmin/_types.py
+++ b/sqladmin/_types.py
@@ -1,7 +1,8 @@
 from typing import Union
 
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import ColumnProperty, RelationshipProperty, Session
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.orm import ColumnProperty, RelationshipProperty
 
 MODEL_ATTR_TYPE = Union[ColumnProperty, RelationshipProperty]
-ENGINE_TYPE = Union[Session, AsyncSession]
+ENGINE_TYPE = Union[Engine, AsyncEngine]

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import Session, sessionmaker
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
-from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
 from starlette.routing import Mount, Route

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable, List, Sequence, Type, Union, no_type_check
+from typing import Any, Callable, List, Optional, Sequence, Type, Union, no_type_check
 
 from jinja2 import ChoiceLoader, FileSystemLoader, PackageLoader
 from sqlalchemy.engine import Engine
@@ -250,7 +250,7 @@ class Admin(BaseAdminView):
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str = None,
-        middlewares: Sequence[Middleware] = None,
+        middlewares: Optional[Sequence[Middleware]] = None,
         debug: bool = False,
         templates_dir: str = "templates",
     ) -> None:

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -250,7 +250,7 @@ class Admin(BaseAdminView):
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str = None,
-        middlewares: Optional[Sequence[Middleware]] = None,
+        middlewares: Optional[Sequence[type]] = None,
         debug: bool = False,
         templates_dir: str = "templates",
     ) -> None:


### PR DESCRIPTION
`_types.py` 

```python
ENGINE_TYPE = Union[Session, AsyncSession]
```

to be

```
ENGINE_TYPE = Union[Engine, AsyncEngine]
```

`application.py`

```python
class Admin(BaseAdminView):

    def __init__(
        ...
        middlewares: Sequence[Middleware] = None,
        ...
    ) -> None:
```

to be
```
class Admin(BaseAdminView):

    def __init__(
        ...
        middlewares: Optional[Sequence[Middleware]] = None,
        ...
    ) -> None:
```
