### PR TITLE
Remove watch in mkdocstrings mkdocs's config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,9 @@ markdown_extensions:
 extra_css:
   - stylesheets/extra.css
 
+watch:
+  - sqladmin/
+
 plugins:
   - search
   - mkdocstrings:
@@ -45,8 +48,6 @@ plugins:
           rendering:
             show_root_heading: true
             show_source: false
-      watch:
-        - sqladmin/
 
 extra:
   analytics:


### PR DESCRIPTION
https://mkdocstrings.github.io/usage/#watch-directories

`watch` config deprecated since version 0.19. use the built-in watch feature.