### PR TITLE
Update tests after starlette upgrade

### DIFF
--- a/tests/test_admin_async.py
+++ b/tests/test_admin_async.py
@@ -501,7 +501,7 @@ async def test_create_endpoint_post_form(client: AsyncClient) -> None:
     async with LocalSession() as s:
         result = await s.execute(stmt)
     assert result.scalar_one() == 1
-    assert response.status_code == 200
+    assert response.status_code == 302
 
     stmt = (
         select(User)
@@ -524,7 +524,7 @@ async def test_create_endpoint_post_form(client: AsyncClient) -> None:
     async with LocalSession() as s:
         result = await s.execute(stmt)
     assert result.scalar_one() == 1
-    assert response.status_code == 200
+    assert response.status_code == 302
 
     stmt = select(Address).limit(1).options(selectinload(Address.user))
     async with LocalSession() as s:
@@ -540,7 +540,7 @@ async def test_create_endpoint_post_form(client: AsyncClient) -> None:
     async with LocalSession() as s:
         result = await s.execute(stmt)
     assert result.scalar_one() == 1
-    assert response.status_code == 200
+    assert response.status_code == 302
 
     stmt = select(Profile).limit(1).options(selectinload(Profile.user))
     async with LocalSession() as s:

--- a/tests/test_admin_async.py
+++ b/tests/test_admin_async.py
@@ -524,7 +524,7 @@ async def test_create_endpoint_post_form(client: AsyncClient) -> None:
     async with LocalSession() as s:
         result = await s.execute(stmt)
     assert result.scalar_one() == 1
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = select(Address).limit(1).options(selectinload(Address.user))
     async with LocalSession() as s:
@@ -540,7 +540,7 @@ async def test_create_endpoint_post_form(client: AsyncClient) -> None:
     async with LocalSession() as s:
         result = await s.execute(stmt)
     assert result.scalar_one() == 1
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = select(Profile).limit(1).options(selectinload(Profile.user))
     async with LocalSession() as s:
@@ -673,7 +673,7 @@ async def test_update_submit_form(client: AsyncClient) -> None:
     data = {"name": "Jack", "email": ""}
     response = await client.post("/admin/user/edit/1", data=data)
 
-    assert response.status_code == 200
+    assert response.status_code == 302
 
     stmt = (
         select(User)

--- a/tests/test_admin_async.py
+++ b/tests/test_admin_async.py
@@ -501,7 +501,7 @@ async def test_create_endpoint_post_form(client: AsyncClient) -> None:
     async with LocalSession() as s:
         result = await s.execute(stmt)
     assert result.scalar_one() == 1
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = (
         select(User)
@@ -673,7 +673,7 @@ async def test_update_submit_form(client: AsyncClient) -> None:
     data = {"name": "Jack", "email": ""}
     response = await client.post("/admin/user/edit/1", data=data)
 
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = (
         select(User)

--- a/tests/test_admin_sync.py
+++ b/tests/test_admin_sync.py
@@ -504,7 +504,7 @@ def test_create_endpoint_post_form(client: TestClient) -> None:
     stmt = select(func.count(Address.id))
     with LocalSession() as s:
         assert s.execute(stmt).scalar_one() == 1
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = select(Address).limit(1).options(selectinload(Address.user))
     with LocalSession() as s:
@@ -518,7 +518,7 @@ def test_create_endpoint_post_form(client: TestClient) -> None:
     stmt = select(func.count(Profile.id))
     with LocalSession() as s:
         assert s.execute(stmt).scalar_one() == 1
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = select(Profile).limit(1).options(selectinload(Profile.user))
     with LocalSession() as s:
@@ -536,7 +536,7 @@ def test_create_endpoint_post_form(client: TestClient) -> None:
     stmt = select(func.count(User.id))
     with LocalSession() as s:
         assert s.execute(stmt).scalar_one() == 2
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = (
         select(User)

--- a/tests/test_admin_sync.py
+++ b/tests/test_admin_sync.py
@@ -483,7 +483,7 @@ def test_create_endpoint_post_form(client: TestClient) -> None:
     stmt = select(func.count(User.id))
     with LocalSession() as s:
         assert s.execute(stmt).scalar_one() == 1
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = (
         select(User)
@@ -649,7 +649,7 @@ def test_update_submit_form(client: TestClient) -> None:
     data = {"name": "Jack", "email": ""}
     response = client.post("/admin/user/edit/1", data=data)
 
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     stmt = (
         select(User)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -57,7 +57,7 @@ def test_login(client: TestClient) -> None:
     response = client.post("/admin/login", data={"username": "a", "password": "b"})
 
     assert len(response.cookies) == 1
-    assert response.status_code == 302
+    assert response.status_code == 200
 
 
 def test_logout(client: TestClient) -> None:


### PR DESCRIPTION
Since starlette 0.21.0 the POST request now follows redirects.