### PR TITLE
Fix a couple of docstrings

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -1000,12 +1000,12 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         return await Query(self).update(pk, data)
 
     async def on_model_delete(self, model: Any) -> None:
-        """Perform some actions before a model is created or updated.
+        """Perform some actions before a model is deleted.
         By default does nothing.
         """
 
     async def after_model_delete(self, model: Any) -> None:
-        """Perform some actions before a model is deleted.
+        """Perform some actions after a model is deleted.
         By default do nothing.
         """
 


### PR DESCRIPTION
The descriptions of `ModelView.on_model_delete` and `ModelView.after_model_delete` seemed incorrect.  

I spotted these errors in the docs:
- https://aminalaee.dev/sqladmin/api_reference/model_view/#sqladmin.models.ModelView.after_model_delete
- https://aminalaee.dev/sqladmin/api_reference/model_view/#sqladmin.models.ModelView.on_model_delete