### PR TITLE
Version 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 0.10.0 - 2023-03-15
 
-## Breaking change
+### Breaking change
 
 * Change AuthenticationBackend `authenticate` signature to support OAuth in https://github.com/aminalaee/sqladmin/pull/440
 
 ### Added
+
 * Add File field in https://github.com/aminalaee/sqladmin/pull/424
 * Support SQLALchemy Interval type in https://github.com/aminalaee/sqladmin/pull/438
 
 ### Fixed
+
 * Fix docstrings by @linomp in https://github.com/aminalaee/sqladmin/pull/434
 * Update to work with Starlette URL type in url_for by @aminalaee in https://github.com/aminalaee/sqladmin/pull/444
 * Fix nullable Integers to accept zero value by @ovginkel in [#445](https://github.com/aminalaee/sqladmin/pull/445)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.10.0 - 2023-03-15
+
+## Breaking change
+
+* Change AuthenticationBackend `authenticate` signature to support OAuth in https://github.com/aminalaee/sqladmin/pull/440
+
+### Added
+* Add File field in https://github.com/aminalaee/sqladmin/pull/424
+* Support SQLALchemy Interval type in https://github.com/aminalaee/sqladmin/pull/438
+
+### Fixed
+* Fix docstrings by @linomp in https://github.com/aminalaee/sqladmin/pull/434
+* Update to work with Starlette URL type in url_for by @aminalaee in https://github.com/aminalaee/sqladmin/pull/444
+* Fix nullable Integers to accept zero value by @ovginkel in [#445](https://github.com/aminalaee/sqladmin/pull/445)
+
+**Full Changelog**: https://github.com/aminalaee/sqladmin/compare/0.9.0...0.10.0
+
 ## Version 0.9.0 - 2023-02-07
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.10.0 - 2023-03-15
+
+## Breaking change
+
+* Change AuthenticationBackend `authenticate` signature to support OAuth in [#440](https://github.com/aminalaee/sqladmin/pull/440)
+
+### Added
+* Add File field in [#424](https://github.com/aminalaee/sqladmin/pull/424)
+* Support SQLALchemy Interval type in [#438](https://github.com/aminalaee/sqladmin/pull/438)
+
+### Fixed
+* Fix docstrings in [#434](https://github.com/aminalaee/sqladmin/pull/434)
+* Update to work with Starlette URL type in url_for in [#444](https://github.com/aminalaee/sqladmin/pull/444)
+* Fix nullable Integers to accept zero value in [#445](https://github.com/aminalaee/sqladmin/pull/445)
+
 ## Version 0.9.0 - 2023-02-07
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,15 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 0.10.0 - 2023-03-15
 
-## Breaking change
+### Breaking change
 
 * Change AuthenticationBackend `authenticate` signature to support OAuth in [#440](https://github.com/aminalaee/sqladmin/pull/440)
 
 ### Added
+
 * Add File field in [#424](https://github.com/aminalaee/sqladmin/pull/424)
 * Support SQLALchemy Interval type in [#438](https://github.com/aminalaee/sqladmin/pull/438)
 
 ### Fixed
+
 * Fix docstrings in [#434](https://github.com/aminalaee/sqladmin/pull/434)
 * Update to work with Starlette URL type in url_for in [#444](https://github.com/aminalaee/sqladmin/pull/444)
 * Fix nullable Integers to accept zero value in [#445](https://github.com/aminalaee/sqladmin/pull/445)

--- a/sqladmin/__init__.py
+++ b/sqladmin/__init__.py
@@ -1,7 +1,7 @@
 from sqladmin.application import Admin, expose
 from sqladmin.models import BaseView, ModelAdmin, ModelView
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 __all__ = [
     "Admin",


### PR DESCRIPTION
## Version 0.10.0 - 2023-03-15

## Breaking change

* Change AuthenticationBackend `authenticate` signature to support OAuth in https://github.com/aminalaee/sqladmin/pull/440

### Added
* Add File field in https://github.com/aminalaee/sqladmin/pull/424
* Support SQLALchemy Interval type in https://github.com/aminalaee/sqladmin/pull/438

### Fixed
* Fix docstrings by @linomp in https://github.com/aminalaee/sqladmin/pull/434
* Update to work with Starlette URL type in url_for by @aminalaee in https://github.com/aminalaee/sqladmin/pull/444
* Fix nullable Integers to accept zero value by @ovginkel in [#445](https://github.com/aminalaee/sqladmin/pull/445)

**Full Changelog**: https://github.com/aminalaee/sqladmin/compare/0.9.0...0.10.0