### PR TITLE
feat: pluralize names with helper method

### DIFF
--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -87,6 +87,14 @@ def prettify_class_name(name: str) -> str:
     return re.sub(r"(?<=.)([A-Z])", r" \1", name)
 
 
+def pluralize(name: str) -> str:
+    # TODO introduce inflect package to do this more cleanly?
+    # https://pypi.org/project/inflect/
+    if name.lower().endswith("s"):
+        return name
+    return name + "s"
+
+
 def slugify_class_name(name: str) -> str:
     dashed = re.sub("(.)([A-Z][a-z]+)", r"\1-\2", name)
     return re.sub("([a-z0-9])([A-Z])", r"\1-\2", dashed).lower()

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -45,6 +45,7 @@ from sqladmin.helpers import (
     get_column_python_type,
     get_primary_key,
     map_attr_to_prop,
+    pluralize,
     prettify_class_name,
     secure_filename,
     slugify_class_name,
@@ -87,7 +88,7 @@ class ModelViewMeta(type):
         cls.model = model
 
         cls.name = attrs.get("name", prettify_class_name(cls.model.__name__))
-        cls.name_plural = attrs.get("name_plural", f"{cls.name}s")
+        cls.name_plural = attrs.get("name_plural", pluralize(cls.name))
         cls.icon = attrs.get("icon")
 
         cls.list_query = attrs.get("list_query", select(model))


### PR DESCRIPTION
Had an issue with models whose names already ends in 's'. While it makes sense in the app to either change the model names or implement name_plural directly, it also helps with the initial app usage if the model names are just a little cleaner earlier on. :)

As noted, the inflect package may be more useful there. I leave that to the maintainer's discretion.