### PR TITLE
Make empty uuids be none instead of empty strings

### DIFF
--- a/sqladmin/fields.py
+++ b/sqladmin/fields.py
@@ -396,3 +396,12 @@ class FileField(fields.FileField):
     """
 
     widget = sqladmin_widgets.FileInputWidget()
+
+
+class NullableStringField(fields.StringField):
+    """
+    String field which stores either a non-empty string or None.
+    """
+
+    def _value(self) -> Optional[str]:
+        return str(self.data) if self.data else None

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -50,6 +50,7 @@ from sqladmin.fields import (
     FileField,
     IntervalField,
     JSONField,
+    NullableStringField,
     QuerySelectField,
     QuerySelectMultipleField,
     Select2TagsField,
@@ -455,7 +456,7 @@ class ModelConverter(ModelConverterBase):
     ) -> UnboundField:
         kwargs.setdefault("validators", [])
         kwargs["validators"].append(validators.UUID())
-        return StringField(**kwargs)
+        return NullableStringField(**kwargs)
 
     @converts(
         "sqlalchemy.dialects.postgresql.base.ARRAY", "sqlalchemy.sql.sqltypes.ARRAY"

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -11,6 +11,7 @@ from sqladmin.fields import (
     DateTimeField,
     IntervalField,
     JSONField,
+    NullableStringField,
     QuerySelectField,
     QuerySelectMultipleField,
     Select2TagsField,
@@ -203,3 +204,23 @@ def test_interval_field() -> None:
 
     form = F(DummyData(interval=[]))
     assert form.validate() is True
+
+
+def test_nullable_string_field() -> None:
+    class F(Form):
+        text = NullableStringField()
+
+    form = F()
+    assert form.validate() is True
+
+    form = F(DummyData(text="hannah-montana"))
+    assert form.validate() is True
+    assert form.text._value() == "hannah-montana"
+
+    form = F(DummyData(text=None))
+    assert form.validate() is True
+    assert form.text._value() is None
+
+    form = F(DummyData(text=""))
+    assert form.validate() is True
+    assert form.text._value() is None

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -196,6 +196,7 @@ async def test_model_form_postgresql() -> None:
     Form = await get_model_form(model=PostgresModel, engine=engine)
 
     assert len(Form()._fields) == 4
+    assert isinstance(Form()._fields["uuid"], NullableStringField)
     assert isinstance(Form()._fields["array"], Select2TagsField)
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -23,7 +23,7 @@ from wtforms import BooleanField, Field, Form, IntegerField, StringField, TimeFi
 from wtforms.fields.core import UnboundField
 
 from sqladmin import ModelView
-from sqladmin.fields import Select2TagsField, SelectField
+from sqladmin.fields import NullableStringField, Select2TagsField, SelectField
 from sqladmin.forms import ModelConverter, converts, get_model_form
 from tests.common import async_engine as engine
 
@@ -278,3 +278,17 @@ async def test_form_override_form_converter() -> None:
 
     assert isinstance(Form()._fields["email"], EmailField)
     assert isinstance(Form()._fields["number"], IntegerField)
+
+
+@pytest.mark.skipif(engine.name != "postgresql", reason="PostgreSQL only")
+async def test_form_with_uuids() -> None:
+    class UUIDModel(Base):
+        __tablename__ = "uuid_model"
+
+        id = Column(UUID(as_uuid=True), primary_key=True)
+        team_id = Column(UUID(as_uuid=True))
+
+    Form = await get_model_form(model=UUIDModel, engine=engine)
+
+    assert len(Form()._fields) == 1
+    assert isinstance(Form()._fields["team_id"], NullableStringField)


### PR DESCRIPTION
## Description
When having a db model with nullable uuid field, the form is sending an empty string when the field is not filled. This makes postgres fail, because from the db point of view, uuid field can be filled with either a valid uuid or null.