### PR TITLE
Support sqlalchemy.sql.sqltypes.Uuid

### DIFF
--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -457,6 +457,7 @@ class ModelConverter(ModelConverterBase):
     @converts(
         "sqlalchemy.dialects.postgresql.base.UUID",
         "sqlalchemy.sql.sqltypes.UUID",
+        "sqlalchemy.sql.sqltypes.Uuid",
         "sqlalchemy_utils.types.uuid.UUIDType",
     )
     def conv_uuid(


### PR DESCRIPTION
Hi there,

It appears that SQLAlchemy 2.0 introduces a new UUID type, `sqlalchemy.sql.sqltypes.Uuid`. This is similar to `sqltypes.UUID` (typed with all caps), except that it also works with databases that don't have a native uuid type, in which case it uses `CHAR(32)`.

https://github.com/sqlalchemy/sqlalchemy/blob/rel_2_0_15/lib/sqlalchemy/sql/sqltypes.py#L3522-L3533

This seems to be the default type used when using declarative mappings with Python's `uuid.UUID` type.