### PR TITLE
Fix Enum in detail page

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -900,19 +900,15 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         return stmt.where(*conditions)
 
     def get_prop_value(
-        self, obj: type, prop: Union[Column, ColumnProperty, RelationshipProperty]
+        self, obj: Any, prop: Union[Column, ColumnProperty, RelationshipProperty]
     ) -> Any:
-        result = None
-
-        if isinstance(prop, Column):
-            result = getattr(obj, prop.name)
-        else:
-            result = getattr(obj, prop.key)
-            result = result.value if isinstance(result, Enum) else result
+        result = getattr(obj, prop.key, None)
+        if result and isinstance(result, Enum):
+            result = result.name
 
         return result
 
-    def get_list_value(self, obj: type, prop: MODEL_PROPERTY) -> Tuple[Any, Any]:
+    def get_list_value(self, obj: Any, prop: MODEL_PROPERTY) -> Tuple[Any, Any]:
         """Get tuple of (value, formatted_value) for the list view."""
         value = self.get_prop_value(obj, prop)
         formatted_value = self._default_formatter(value)
@@ -922,7 +918,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
             formatted_value = formatter(obj, prop)
         return value, formatted_value
 
-    def get_detail_value(self, obj: type, prop: MODEL_PROPERTY) -> Tuple[Any, Any]:
+    def get_detail_value(self, obj: Any, prop: MODEL_PROPERTY) -> Tuple[Any, Any]:
         """Get tuple of (value, formatted_value) for the detail view."""
         value = self.get_prop_value(obj, prop)
         formatted_value = self._default_formatter(value)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,8 +41,6 @@ class User(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String)
-    role = Column(Enum(Role))
-    status = Column(Enum(Status))
 
     addresses = relationship("Address", back_populates="user")
     profile = relationship("Profile", back_populates="user", uselist=False)
@@ -62,6 +60,8 @@ class Profile(Base):
 
     id = Column(Integer, primary_key=True)
     is_active = Column(Boolean)
+    role = Column(Enum(Role))
+    status = Column(Enum(Status))
     user_id = Column(Integer, ForeignKey("users.id"), unique=True)
 
     user = relationship("User", back_populates="profile")
@@ -522,11 +522,11 @@ def test_model_columns_all_keyword() -> None:
 
 
 def test_get_prop_value() -> None:
-    class UserAdmin(ModelView, model=User):
+    class ProfileAdmin(ModelView, model=Profile):
         ...
 
-    user = User(name="batman", role=Role.ADMIN, status=Status.ACTIVE)
+    profile = Profile(is_active=True, role=Role.ADMIN, status=Status.ACTIVE)
 
-    assert UserAdmin().get_prop_value(user, User.name) == "batman"
-    assert UserAdmin().get_prop_value(user, User.role) == "ADMIN"
-    assert UserAdmin().get_prop_value(user, User.status) == "ACTIVE"
+    assert ProfileAdmin().get_prop_value(profile, Profile.is_active) is True
+    assert ProfileAdmin().get_prop_value(profile, Profile.role) == "ADMIN"
+    assert ProfileAdmin().get_prop_value(profile, Profile.status) == "ACTIVE"


### PR DESCRIPTION
Closes https://github.com/aminalaee/sqladmin/issues/524

For Enum columns, it's more meaningful to display the Enum name, instead of the value. For IntEnum case for example the name is more useful.