### PR TITLE
Use url_for for the create form action

### DIFF
--- a/sqladmin/templates/create.html
+++ b/sqladmin/templates/create.html
@@ -6,7 +6,7 @@
       <h3 class="card-title">New {{ model_view.name }}</h3>
     </div>
     <div class="card-body border-bottom py-3">
-      <form action="{{ request.url }}" method="POST" enctype="multipart/form-data">
+      <form action="{{ url_for('admin:create', identity=model_view.identity) }}" method="POST" enctype="multipart/form-data">
         <fieldset class="form-fieldset">
           {% for field in form %}
           <div class="mb-3 form-group row">


### PR DESCRIPTION
The current template ignores the root_path for the app.  By using the url_for function, the root_path is used when applied.