### PR TITLE
fix: remove request.url usage in templates

### DIFF
--- a/sqladmin/templates/create.html
+++ b/sqladmin/templates/create.html
@@ -6,7 +6,8 @@
       <h3 class="card-title">New {{ model_view.name }}</h3>
     </div>
     <div class="card-body border-bottom py-3">
-      <form action="{{ request.url }}" method="POST" enctype="multipart/form-data">
+      {# Note, leave action empty to default to current URL (whichever that might be in the client browser) #}
+      <form action="" method="POST" enctype="multipart/form-data">
         <fieldset class="form-fieldset">
           {% for field in form %}
           <div class="mb-3 form-group row">

--- a/sqladmin/templates/edit.html
+++ b/sqladmin/templates/edit.html
@@ -6,7 +6,8 @@
       <h3 class="card-title">Edit {{ model_view.name }}</h3>
     </div>
     <div class="card-body border-bottom py-3">
-      <form action="{{ request.url }}" method="POST" enctype="multipart/form-data">
+      {# Note, leave action empty to default to current URL (whichever that might be in the client browser) #}
+      <form action="" method="POST" enctype="multipart/form-data">
         <fieldset class="form-fieldset">
           {% for field in form %}
           <div class="mb-3 form-group row">

--- a/sqladmin/templates/list.html
+++ b/sqladmin/templates/list.html
@@ -83,11 +83,12 @@
             <th>
               {% if name in model_view._sort_fields %}
               {% if request.query_params.get("sortBy") == name and request.query_params.get("sort") == "asc" %}
-              <a href="{{ request.url.include_query_params(sort='desc') }}"><i class="fa-solid fa-arrow-down"></i> {{ name }}</a>
+              {# Note, leave href base URLs empty to default to current URL (whichever that might be in the client browser) #}
+              <a href="?sort=desc"><i class="fa-solid fa-arrow-down"></i> {{ name }}</a>
               {% elif request.query_params.get("sortBy") == name and request.query_params.get("sort") == "desc" %}
-              <a href="{{ request.url.include_query_params(sort='asc') }}"><i class="fa-solid fa-arrow-up"></i> {{ name }}</a>
+              <a href="?sort=asc"><i class="fa-solid fa-arrow-up"></i> {{ name }}</a>
               {% else %}
-              <a href="{{ request.url.include_query_params(sortBy=name, sort='asc') }}">{{ name }}</a>
+              <a href="?sortBy={{ name | urlencode }}&sort=asc">{{ name }}</a>
               {% endif %}
               {% else %}
               {{ name }}
@@ -175,7 +176,8 @@
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}
-          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option) }}">
+          {# Note, leave href base URLs empty to default to current URL (whichever that might be in the client browser) #}
+          <a class="dropdown-item" href="?pageSize={{ page_size_option | urlencode }}">
             {{ page_size_option }} / Page
           </a>
           {% endfor %}

--- a/sqladmin/templates/login.html
+++ b/sqladmin/templates/login.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% block body %}
 <div class="d-flex align-items-center justify-content-center vh-100">
-  <form class="Fcol-lg-6 col-md-6 card card-md" action="{{ request.url }}" method="POST" autocomplete="off">
+  {# Note, leave action empty to default to current URL (whichever that might be in the client browser) #}
+  <form class="Fcol-lg-6 col-md-6 card card-md" action="" method="POST" autocomplete="off">
     <div class="card-body">
       <h2 class="card-title text-center mb-4">Login to {{ admin.title }}</h2>
       <div class="mb-3">


### PR DESCRIPTION
`request.url` is a handy tool to reach for to get the current URL, but it depends heavily on the configuration of the application. This can return the incorrect URL or incorrect scheme when used behind a proxy, for instance.

Instead of going the route of implementing middleware or other config settings to correct it, this change takes advantage of default browser behavior. An empty URL used for `href` or `action` is automatically filled with the full URL from the browser's context. This also allows relative URLs from the current location, including URLs that require query params (these can include other Jinja variables so long as we use the `urlencode` filter for safety).