### PR TITLE
Fix docs: Cookbook, Using a request object

### DIFF
--- a/docs/cookbook/using_request_object.md
+++ b/docs/cookbook/using_request_object.md
@@ -32,7 +32,7 @@ This can be done by overriding the `insert_model` method:
 ```python
 class PostAdmin(ModelView, model=Post):
     async def insert_model(self, request, data):
-        data["user_id"] = request.user.id
+        data["author_id"] = request.user.id
         return await super().insert_model(request, data)
 ```
 


### PR DESCRIPTION
Fix docs: Cookbook > Using a request object. Post is created by author_id.