### PR TITLE
Implement feature to filter for multiple search words in list

### DIFF
--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -739,6 +739,10 @@ async def test_searchable_list(client: AsyncClient) -> None:
         session.add(user)
         user = User(name="Boss")
         session.add(user)
+        user = User(name="John Doe")
+        session.add(user)
+        user = User(name="John")
+        session.add(user)
         await session.commit()
 
     response = await client.get("/admin/user/list")
@@ -762,6 +766,31 @@ async def test_searchable_list(client: AsyncClient) -> None:
     response = await client.get("/admin/user/list?search=rose")
 
     assert "/admin/user/details/1" not in response.text
+
+    response = await client.get("/admin/user/list?search=ross boss")
+    assert "/admin/user/details/1" in response.text
+    assert "/admin/user/details/2" in response.text
+    assert "/admin/user/details/3" not in response.text
+    assert (
+        "Showing <span>1</span> to <span>2</span> of <span>2</span> items"
+        in response.text
+    )
+
+    response = await client.get('/admin/user/list?search="John"')
+    assert "/admin/user/details/3" in response.text
+    assert "/admin/user/details/4" in response.text
+    assert (
+        "Showing <span>1</span> to <span>2</span> of <span>2</span> items"
+        in response.text
+    )
+
+    response = await client.get('/admin/user/list?search="john Doe"')
+    assert "/admin/user/details/3" in response.text
+    assert "/admin/user/details/4" not in response.text
+    assert (
+        "Showing <span>1</span> to <span>1</span> of <span>1</span> items"
+        in response.text
+    )
 
 
 async def test_sortable_list(client: AsyncClient) -> None:

--- a/tests/test_views/test_view_sync.py
+++ b/tests/test_views/test_view_sync.py
@@ -705,6 +705,10 @@ def test_searchable_list(client: TestClient) -> None:
         session.add(user)
         user = User(name="Boss")
         session.add(user)
+        user = User(name="John Doe")
+        session.add(user)
+        user = User(name="John")
+        session.add(user)
         session.commit()
 
     response = client.get("/admin/user/list")
@@ -726,6 +730,31 @@ def test_searchable_list(client: TestClient) -> None:
 
     response = client.get("/admin/user/list?search=rose")
     assert "/admin/user/details/1" not in response.text
+
+    response = client.get("/admin/user/list?search=ross boss")
+    assert "/admin/user/details/1" in response.text
+    assert "/admin/user/details/2" in response.text
+    assert "/admin/user/details/3" not in response.text
+    assert (
+        "Showing <span>1</span> to <span>2</span> of <span>2</span> items"
+        in response.text
+    )
+
+    response = client.get('/admin/user/list?search="John"')
+    assert "/admin/user/details/3" in response.text
+    assert "/admin/user/details/4" in response.text
+    assert (
+        "Showing <span>1</span> to <span>2</span> of <span>2</span> items"
+        in response.text
+    )
+
+    response = client.get('/admin/user/list?search="john Doe"')
+    assert "/admin/user/details/3" in response.text
+    assert "/admin/user/details/4" not in response.text
+    assert (
+        "Showing <span>1</span> to <span>1</span> of <span>1</span> items"
+        in response.text
+    )
 
 
 def test_sortable_list(client: TestClient) -> None:


### PR DESCRIPTION
I implemented a feature to allow searching for multiple search terms separated by space char in list view.
Quoted strings can be used to still search for a single search term.

For example searching for:
- John Doe retrieves all users that have either John or Doe in the name
- "John Doe" retrieves only users that have the exact string "John Doe" in the name.

This covers discussion https://github.com/aminalaee/sqladmin/discussions/543 by implementing OR search terms separated by spaced but also ensures that searching for terms which contain spaces is still possible using AND (by using quotes).