### PR TITLE
Fix 'itsdangerous' import error when not using Authentication Backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "starlette",
+  "starlette[full]",
   "typing_extensions>=4.0;python_version < '3.8'",
   "sqlalchemy >=1.4",
   "wtforms >=3, <4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "starlette[full]",
+  "starlette",
   "typing_extensions>=4.0;python_version < '3.8'",
   "sqlalchemy >=1.4",
   "wtforms >=3, <4",

--- a/sqladmin/authentication.py
+++ b/sqladmin/authentication.py
@@ -3,7 +3,6 @@ import inspect
 from typing import Any, Callable, Union
 
 from starlette.middleware import Middleware
-from starlette.middleware.sessions import SessionMiddleware
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
 
@@ -15,6 +14,8 @@ class AuthenticationBackend:
     """
 
     def __init__(self, secret_key: str) -> None:
+        from starlette.middleware.sessions import SessionMiddleware
+
         self.middlewares = [
             Middleware(SessionMiddleware, secret_key=secret_key),
         ]


### PR DESCRIPTION
## Issue
When importing `sqladmin.Admin`:

```py
from sqladmin import Admin
```

...the application imports from `.authentication`: https://github.com/aminalaee/sqladmin/blob/724b9a966262876701c24cfa051aeb663d385d48/sqladmin/application.py#L34

Which in turn calls `starlette.middleware.sessions`: https://github.com/aminalaee/sqladmin/blob/724b9a966262876701c24cfa051aeb663d385d48/sqladmin/authentication.py#L6

And in starlette package, `middleware.session` tries to import `itsdangerous`: https://github.com/encode/starlette/blob/cb6d284877cd359a21a0f31ebf8103a7b285a848/starlette/middleware/sessions.py#L5

However, this package is *not* installed automatically: it's part of the "full" deps: https://github.com/encode/starlette/blob/cb6d284877cd359a21a0f31ebf8103a7b285a848/pyproject.toml#L37

Therefore, it's easily possible to install `sqladmin` and *not* this crucial sub-dependency, creating an error when trying to run the site:
![image](https://github.com/aminalaee/sqladmin/assets/9964605/ea827940-411c-4bd3-b0e8-7f5f0c3fef1d)

## Solution
Either:
1. Mark `itsdangerous` as a named dependency here (which seems odd to name a sub-dependency just to alleviate this issue); or
2. Install `starlette[full]` as a main dependency, ensuring all dependencies are covered up front.

This PR is a simple change implementing the latter.