### PR TITLE
Add customized sort query signature (#624)

### DIFF
--- a/docs/api_reference/model_view.md
+++ b/docs/api_reference/model_view.md
@@ -48,6 +48,7 @@
         - list_query
         - count_query
         - search_query
+        - sort_query
         - on_model_change
         - after_model_change
         - on_model_delete

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -1060,6 +1060,8 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         A method that is called every time the fields are sorted
         and that can be customized.
         By default, sorting takes place by default fields.
+
+        The 'sortBy' and 'sort' query parameters are available in this request context.
         """
         sort_by = request.query_params.get("sortBy", None)
         sort = request.query_params.get("sort", "asc")

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -777,23 +777,12 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         page_size = int(request.query_params.get("pageSize", 0))
         page_size = min(page_size or self.page_size, max(self.page_size_options))
         search = request.query_params.get("search", None)
-        sort_by = request.query_params.get("sortBy", None)
-        sort = request.query_params.get("sort", "asc")
 
         stmt = self.list_query(request)
         for relation in self._list_relations:
             stmt = stmt.options(joinedload(relation))
 
-        if sort_by:
-            sort_fields = [(sort_by, sort == "desc")]
-        else:
-            sort_fields = self._get_default_sort()
-
-        for sort_field, is_desc in sort_fields:
-            if is_desc:
-                stmt = stmt.order_by(desc(sort_field))
-            else:
-                stmt = stmt.order_by(asc(sort_field))
+        stmt = self.sort_query(stmt, request)
 
         if search:
             stmt = self.search_query(stmt=stmt, term=search)
@@ -954,6 +943,20 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
             defaults=self._list_prop_names,
         )
 
+    def _get_sort_fields(self, request: Request) -> List[Tuple[str, bool]]:
+        """Gets the fields to sort.
+        If there are no fields, returns the default sort fields.
+        """
+        sort_by = request.query_params.get("sortBy", None)
+        sort = request.query_params.get("sort", "asc")
+
+        if sort_by:
+            sort_fields = [(sort_by, sort == "desc")]
+        else:
+            sort_fields = self._get_default_sort()
+
+        return sort_fields
+
     async def on_model_change(self, data: dict, model: Any, is_created: bool) -> None:
         """Perform some actions before a model is created or updated.
         By default does nothing.
@@ -1065,6 +1068,23 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         """
 
         return select(func.count(self.pk_columns[0]))
+
+    def sort_query(self, stmt: Select, request: Request) -> Select:
+        """
+        A method that is called every time the fields are sorted
+        and that can be customized.
+        By default, sorting takes place by default fields.
+        """
+
+        sort_fields = self._get_sort_fields(request)
+
+        for sort_field, is_desc in sort_fields:
+            if is_desc:
+                stmt = stmt.order_by(desc(sort_field))
+            else:
+                stmt = stmt.order_by(asc(sort_field))
+
+        return stmt
 
     def get_export_name(self, export_type: str) -> str:
         """The file name when exporting."""

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -943,20 +943,6 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
             defaults=self._list_prop_names,
         )
 
-    def _get_sort_fields(self, request: Request) -> List[Tuple[str, bool]]:
-        """Gets the fields to sort.
-        If there are no fields, returns the default sort fields.
-        """
-        sort_by = request.query_params.get("sortBy", None)
-        sort = request.query_params.get("sort", "asc")
-
-        if sort_by:
-            sort_fields = [(sort_by, sort == "desc")]
-        else:
-            sort_fields = self._get_default_sort()
-
-        return sort_fields
-
     async def on_model_change(self, data: dict, model: Any, is_created: bool) -> None:
         """Perform some actions before a model is created or updated.
         By default does nothing.
@@ -1075,8 +1061,13 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         and that can be customized.
         By default, sorting takes place by default fields.
         """
+        sort_by = request.query_params.get("sortBy", None)
+        sort = request.query_params.get("sort", "asc")
 
-        sort_fields = self._get_sort_fields(request)
+        if sort_by:
+            sort_fields = [(sort_by, sort == "desc")]
+        else:
+            sort_fields = self._get_default_sort()
 
         for sort_field, is_desc in sort_fields:
             if is_desc:


### PR DESCRIPTION
Implementation Issue (#624)
I added request to the sort_query method. 
It would be possible to sort only by clicking on the column, but this would reduce the flexibility of customization.