### PR TITLE
Avoid populating Select2 input with existing options

### DIFF
--- a/sqladmin/widgets.py
+++ b/sqladmin/widgets.py
@@ -65,6 +65,7 @@ class Select2TagsWidget(widgets.Select):
     def __call__(self, field: Field, **kwargs: Any) -> str:
         kwargs.setdefault("data-role", "select2-tags")
         kwargs.setdefault("data-json", json.dumps(field.data))
+        kwargs.setdefault("multiple", "multiple")
         return super().__call__(field, **kwargs)
 
 


### PR DESCRIPTION
Resolves #622.

After searching through the Select2 docs, I've found that pre-population can be avoided by adding a `multiple` attribute: https://select2.org/getting-started/basic-usage#multi-select-boxes-pillbox

I confirm the update fixes the linked issue.

Again, huge thanks to @aminalaee for his work and research on the clues to resolve the issue.

Still, I am not sure about the next stuff:
- Should I add some tests, and if yes, where and how?
- Can my change break somebody's setup?