### PR TITLE
Fix object_identifier_values type casting

### DIFF
--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -230,8 +230,8 @@ def _object_identifier_parts(id_string: str, model: type) -> Tuple[str, ...]:
 def object_identifier_values(id_string: str, model: type) -> tuple:
     values = []
     pks = get_primary_keys(model)
-    for pk, part in zip(pks, _object_identifier_parts(id_string, model)):
-        values.append(get_column_python_type(pk)(part))
+    for _, part in zip(pks, _object_identifier_parts(id_string, model)):
+        values.append(str(part))
     return tuple(values)
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -85,8 +85,8 @@ def test_single_pk_id_values():
     assert object_identifier_values("C:\\Files\\", Family) == ("C:\\Files\\",)
     assert object_identifier_values(r"1;2\;3", Family) == (r"1;2\;3",)
 
-    assert object_identifier_values(str(0), Profile) == (0,)
-    assert object_identifier_values(str(3217), Profile) == (3217,)
+    assert object_identifier_values("0", Profile) == ("0",)
+    assert object_identifier_values("3217", Profile) == ("3217",)
 
 
 def test_multi_pk_identifier():
@@ -103,11 +103,11 @@ def test_multi_pk_id_values():
     def id_values(ident):
         return object_identifier_values(ident, Person)
 
-    assert id_values("Johnson;7;A") == ("Johnson", 7, "A")
-    assert id_values(r"C:\\Files\\;404;F") == ("C:\\Files\\", 404, "F")
-    assert id_values(r"1\;2\\\;3;201;S") == (r"1;2\;3", 201, "S")
-    assert id_values("Doe;3;\\\\") == ("Doe", 3, "\\")
-    assert id_values(";1;") == ("", 1, "")
+    assert id_values("Johnson;7;A") == ("Johnson", "7", "A")
+    assert id_values(r"C:\\Files\\;404;F") == ("C:\\Files\\", "404", "F")
+    assert id_values(r"1\;2\\\;3;201;S") == (r"1;2\;3", "201", "S")
+    assert id_values("Doe;3;\\\\") == ("Doe", "3", "\\")
+    assert id_values(";1;") == ("", "1", "")
 
 
 def test_catch_malformed_id():


### PR DESCRIPTION
Related to https://github.com/aminalaee/sqladmin/issues/635

I think the down-side with this is that not doing the type casting might affect query performance.