### PR TITLE
Fix docs: Cookbook form_ajax_refs definition

### DIFF
--- a/docs/cookbook/optimize_relationship_loading.md
+++ b/docs/cookbook/optimize_relationship_loading.md
@@ -39,9 +39,9 @@ you can use `form_ajax_refs` to load `Child` objects with an AJAX call:
 ```py
 class ParentAdmin(ModelView, model=Parent):
     form_ajax_refs = {
-        "child": {
+        "children": {
             "fields": ("id",),
-            "order_by": ("id",),
+            "order_by": "id",
         }
     }
 ```


### PR DESCRIPTION
I really don't understand it deeply but the original code example for `form_ajax_refs` from the cookbook does not work.
It is not documented anywhere why, I just found the answer in `tests/test_ajax.py`.

 - There is no element `child` in the `Parent` class but there is a `children` relationship
 - `"order_by": ("id",)` just does not work (`sqlalchemy.exc.ArgumentError: ORDER BY expression expected, got ('id',).`) but `"order_by": "id"` works

It would be also fine to add `__str__` method to the example implementation of the class `Child` to be more clear about what is used in the list.

