### PR TITLE
Fix docs: icon not rendered in writing custom views

### DIFF
--- a/docs/writing_custom_views.md
+++ b/docs/writing_custom_views.md
@@ -11,7 +11,7 @@ To add custom views to the Admin interface, you can use the `BaseView` included 
 
     class ReportView(BaseView):
         name = "Report Page"
-        icon = "fa-chart-line"
+        icon = "fa-solid fa-chart-line"
 
         @expose("/report", methods=["GET"])
         async def report_page(self, request):
@@ -62,7 +62,7 @@ The example above was very basic and you probably want to access database and SQ
 
     class ReportView(BaseView):
         name = "Report Page"
-        icon = "fa-chart-line"
+        icon = "fa-solid fa-chart-line"
 
         @expose("/report", methods=["GET"])
         async def report_page(self, request):


### PR DESCRIPTION
We should add `fa-solid` to properly render the fontawesome icon

Before:
<img width="120" alt="before_docs" src="https://github.com/aminalaee/sqladmin/assets/33952122/c08014ff-cf25-4f7b-80dc-017312acf07d">

After:
<img width="125" alt="after_docs" src="https://github.com/aminalaee/sqladmin/assets/33952122/57d04ad4-3b00-4900-82da-0e8dc5c85983">
