### PR TITLE
Version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.16.0 - 2023-11-14
+
+### Added
+* Switch to async templates by @aminalaee in https://github.com/aminalaee/sqladmin/pull/652
+* Allow using related model fields in list/details page by @aminalaee in https://github.com/aminalaee/sqladmin/pull/653
+* Allow sort by related model field by @aminalaee in https://github.com/aminalaee/sqladmin/pull/654
+* Add search by related model field by @aminalaee in https://github.com/aminalaee/sqladmin/pull/655
+* Expose request to model events by @holdmybeer1min in https://github.com/aminalaee/sqladmin/pull/660
+
+### Fixed
+* Allow model columns to bear the same name as reserved wtforms.BaseForm attributes by @brouberol in https://github.com/aminalaee/sqladmin/pull/658
+* Change pk converter in routes by @aminalaee in https://github.com/aminalaee/sqladmin/pull/666
+* Fix multiple PK model containing boolean values by @ncarvajalc in https://github.com/aminalaee/sqladmin/pull/670
+* Fix brand icon is not showing by @WiraDKP in https://github.com/aminalaee/sqladmin/pull/665
+
+**Full Changelog**: https://github.com/aminalaee/sqladmin/compare/0.15.2...0.16.0
+
 ## Version 0.15.1 - 2023-10-02
 
 ### Fixed

--- a/sqladmin/__init__.py
+++ b/sqladmin/__init__.py
@@ -1,7 +1,7 @@
 from sqladmin.application import Admin, action, expose
 from sqladmin.models import BaseView, ModelView
 
-__version__ = "0.15.2"
+__version__ = "0.16.0"
 
 __all__ = [
     "Admin",


### PR DESCRIPTION
## This release contains multiple breaking changes

### Added
* Switch to async templates by @aminalaee in https://github.com/aminalaee/sqladmin/pull/652
* Allow using related model fields in list/details page by @aminalaee in https://github.com/aminalaee/sqladmin/pull/653
* Allow sort by related model field by @aminalaee in https://github.com/aminalaee/sqladmin/pull/654
* Add search by related model field by @aminalaee in https://github.com/aminalaee/sqladmin/pull/655
* Expose request to model events by @holdmybeer1min in https://github.com/aminalaee/sqladmin/pull/660

### Fixed
* Allow model columns to bear the same name as reserved wtforms.BaseForm attributes by @brouberol in https://github.com/aminalaee/sqladmin/pull/658
* Change pk converter in routes by @aminalaee in https://github.com/aminalaee/sqladmin/pull/666
* Fix multiple PK model containing boolean values by @ncarvajalc in https://github.com/aminalaee/sqladmin/pull/670
* Fix docs: Cookbook form_ajax_refs definition by @j123b567 in https://github.com/aminalaee/sqladmin/pull/659
* Fix docs: icon not rendered in writing custom views by @WiraDKP in https://github.com/aminalaee/sqladmin/pull/664
* Fix brand icon is not showing by @WiraDKP in https://github.com/aminalaee/sqladmin/pull/665

## New Contributors
* @j123b567 made their first contribution in https://github.com/aminalaee/sqladmin/pull/659
* @WiraDKP made their first contribution in https://github.com/aminalaee/sqladmin/pull/664
* @holdmybeer1min made their first contribution in https://github.com/aminalaee/sqladmin/pull/660
* @brouberol made their first contribution in https://github.com/aminalaee/sqladmin/pull/658
* @ncarvajalc made their first contribution in https://github.com/aminalaee/sqladmin/pull/670

**Full Changelog**: https://github.com/aminalaee/sqladmin/compare/0.15.2...0.16.0