### PR TITLE
🔨 Add http_exception handler to Admin class

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -374,7 +374,7 @@ class Admin(BaseAdminView):
 
         async def http_exception(
             request: Request, exc: Exception
-        ) -> Awaitable[Response]:
+        ) -> Union[Response, Awaitable[Response]]:
             assert isinstance(exc, HTTPException)
             context = {
                 "status_code": exc.status_code,

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -5,6 +5,7 @@ from types import MethodType
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     List,
     Optional,
@@ -14,7 +15,6 @@ from typing import (
     Union,
     cast,
     no_type_check,
-    Awaitable,
 )
 from urllib.parse import urljoin
 

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -14,6 +14,7 @@ from typing import (
     Union,
     cast,
     no_type_check,
+    Awaitable,
 )
 from urllib.parse import urljoin
 
@@ -371,15 +372,17 @@ class Admin(BaseAdminView):
 
         statics = StaticFiles(packages=["sqladmin"])
 
-        # def http_exception(request: Request, exc: Exception) -> Response:
-        #     assert isinstance(exc, HTTPException)
-        #     context = {
-        #         "status_code": exc.status_code,
-        #         "message": exc.detail,
-        #     }
-        #     return self.templates.TemplateResponse(
-        #         request, "error.html", context, status_code=exc.status_code
-        #     )
+        async def http_exception(
+            request: Request, exc: Exception
+        ) -> Awaitable[Response]:
+            assert isinstance(exc, HTTPException)
+            context = {
+                "status_code": exc.status_code,
+                "message": exc.detail,
+            }
+            return await self.templates.TemplateResponse(
+                request, "error.html", context, status_code=exc.status_code
+            )
 
         routes = [
             Mount("/statics", app=statics, name="statics"),
@@ -417,7 +420,7 @@ class Admin(BaseAdminView):
         ]
 
         self.admin.router.routes = routes
-        # self.admin.exception_handlers = {HTTPException: http_exception}
+        self.admin.exception_handlers = {HTTPException: http_exception}
         self.admin.debug = debug
         self.app.mount(base_url, app=self.admin, name="admin")
 

--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -159,7 +159,7 @@ class _PseudoBuffer:
 
 
 def stream_to_csv(
-    callback: Callable[[Writer], AsyncGenerator[T, None]]
+    callback: Callable[[Writer], AsyncGenerator[T, None]],
 ) -> Generator[T, None, None]:
     """Function that takes a callable (that yields from a CSV Writer), and
     provides it a writer that streams the output directly instead of


### PR DESCRIPTION
Fixed the exception handler to bring a template for the errors using an awaitable response to be matched with Starlette exception handler type hint:

```python
HTTPExceptionHandler = typing.Callable[
    ["Request", Exception], typing.Union["Response", typing.Awaitable["Response"]]
]
```

This PR solved the #693 issue.