### PR TITLE
Fix Category not respecting is_visible and is_accessible

### DIFF
--- a/sqladmin/_menu.py
+++ b/sqladmin/_menu.py
@@ -42,7 +42,7 @@ class ItemMenu:
 class CategoryMenu(ItemMenu):
     def is_active(self, request: Request) -> bool:
         return any(
-            c.is_active(request) and c.is_accessible(request) for c in self.children
+            c.is_visible(request) and c.is_accessible(request) for c in self.children
         )
 
     @property

--- a/sqladmin/templates/_macros.html
+++ b/sqladmin/templates/_macros.html
@@ -1,30 +1,32 @@
 {% macro menu_category(menu, request) %}
-  {% if  menu.is_active(request) %}
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle {% if menu.is_active(request) %}active{% endif %}" data-bs-toggle="dropdown" href="#">
-        <span class="nav-link-icon d-md-none d-lg-inline-block">
-          {% if menu.icon %}<i class="{{ menu.icon }}"></i>{% endif %}
-        </span>
-        <span class="nav-link-title">{{ menu.display_name }}</span>
-      </a>
-      <div class="dropdown-menu show">
-        <div class="dropdown-menu-columns">
-          <div class="dropdown-menu-column">
-            {% for sub_menu in menu.children %}
-              {% if sub_menu.is_visible(request) and sub_menu.is_accessible(request) %}
-                <a class="nav-link ps-lg-3 {% if sub_menu.is_active(request) %}active{% endif %}" href="{{ sub_menu.url(request) }}">
-                  <span class="nav-link-icon d-md-none d-lg-inline-block">
-                    {% if sub_menu.icon %}<i class="{{ sub_menu.icon }}"></i>{% endif %}
-                  </span>
-                  <span class="nav-link-title">{{ sub_menu.display_name }}</span>
-                </a>
-              {% endif %}
-            {% endfor %}
-          </div>
-        </div>
+{% if menu.is_active(request) %}
+<li class="nav-item dropdown">
+  <a class="nav-link dropdown-toggle {% if menu.is_active(request) %}active{% endif %}" data-bs-toggle="dropdown"
+    href="#">
+    <span class="nav-link-icon d-md-none d-lg-inline-block">
+      {% if menu.icon %}<i class="{{ menu.icon }}"></i>{% endif %}
+    </span>
+    <span class="nav-link-title">{{ menu.display_name }}</span>
+  </a>
+  <div class="dropdown-menu show">
+    <div class="dropdown-menu-columns">
+      <div class="dropdown-menu-column">
+        {% for sub_menu in menu.children %}
+        {% if sub_menu.is_visible(request) and sub_menu.is_accessible(request) %}
+        <a class="nav-link ps-lg-3 {% if sub_menu.is_active(request) %}active{% endif %}"
+          href="{{ sub_menu.url(request) }}">
+          <span class="nav-link-icon d-md-none d-lg-inline-block">
+            {% if sub_menu.icon %}<i class="{{ sub_menu.icon }}"></i>{% endif %}
+          </span>
+          <span class="nav-link-title">{{ sub_menu.display_name }}</span>
+        </a>
+        {% endif %}
+        {% endfor %}
       </div>
-    </li>
-  {% endif %}
+    </div>
+  </div>
+</li>
+{% endif %}
 {% endmacro %}
 
 

--- a/sqladmin/templates/_macros.html
+++ b/sqladmin/templates/_macros.html
@@ -29,7 +29,6 @@
 {% endif %}
 {% endmacro %}
 
-
 {% macro menu_item(menu, request) %}
 {% if menu.is_visible(request) and menu.is_accessible(request) %}
 <li class="nav-item">

--- a/sqladmin/templates/_macros.html
+++ b/sqladmin/templates/_macros.html
@@ -1,31 +1,32 @@
 {% macro menu_category(menu, request) %}
-{% if menu.is_visible(request) and menu.is_accessible(request) %}
-<li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle {% if menu.is_active(request) %}active{% endif %}" data-bs-toggle="dropdown"
-    href="#">
-    <span class="nav-link-icon d-md-none d-lg-inline-block">
-      {% if menu.icon %}<i class="{{ menu.icon }}"></i>{% endif %}
-    </span>
-    <span class="nav-link-title">{{ menu.display_name }}</span>
-  </a>
-  <div class="dropdown-menu show">
-    <div class="dropdown-menu-columns">
-      <div class="dropdown-menu-column">
-        {% for sub_menu in menu.children %}
-        <a class="nav-link ps-lg-3 {% if sub_menu.is_active(request) %}active{% endif %}"
-          href="{{ sub_menu.url(request) }}">
-          <span class="nav-link-icon d-md-none d-lg-inline-block">
-            {% if sub_menu.icon %}<i class="{{ sub_menu.icon }}"></i>{% endif %}
-          </span>
-          <span class="nav-link-title">{{ sub_menu.display_name }}</span>
-        </a>
-        {% endfor %}
+  {% if  menu.is_active(request) %}
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle {% if menu.is_active(request) %}active{% endif %}" data-bs-toggle="dropdown" href="#">
+        <span class="nav-link-icon d-md-none d-lg-inline-block">
+          {% if menu.icon %}<i class="{{ menu.icon }}"></i>{% endif %}
+        </span>
+        <span class="nav-link-title">{{ menu.display_name }}</span>
+      </a>
+      <div class="dropdown-menu show">
+        <div class="dropdown-menu-columns">
+          <div class="dropdown-menu-column">
+            {% for sub_menu in menu.children %}
+              {% if sub_menu.is_visible(request) and sub_menu.is_accessible(request) %}
+                <a class="nav-link ps-lg-3 {% if sub_menu.is_active(request) %}active{% endif %}" href="{{ sub_menu.url(request) }}">
+                  <span class="nav-link-icon d-md-none d-lg-inline-block">
+                    {% if sub_menu.icon %}<i class="{{ sub_menu.icon }}"></i>{% endif %}
+                  </span>
+                  <span class="nav-link-title">{{ sub_menu.display_name }}</span>
+                </a>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
-</li>
-{% endif %}
+    </li>
+  {% endif %}
 {% endmacro %}
+
 
 {% macro menu_item(menu, request) %}
 {% if menu.is_visible(request) and menu.is_accessible(request) %}


### PR DESCRIPTION
FIx:
1)It is necessary to add a check for displaying models in categories for which is_visible or is_accessible are equal to False. Because now they are displayed in any case, even if there are no rights. 
2)  if there are no models in the category for which is_visible and is_accessible are equal to True, then the category does not need to be shown.