### PR TITLE
Move non-field-specific errors to top of edit and create forms

### DIFF
--- a/sqladmin/templates/create.html
+++ b/sqladmin/templates/create.html
@@ -8,6 +8,11 @@
     <div class="card-body border-bottom py-3">
       <form action="{{ url_for('admin:create', identity=model_view.identity) }}" method="POST"
         enctype="multipart/form-data">
+        <div class="row">
+          {% if error %}
+          <div class="alert alert-danger" role="alert">{{ error }}</div>
+          {% endif %}
+        </div>
         <fieldset class="form-fieldset">
           {% for field in form %}
           <div class="mb-3 form-group row">
@@ -26,9 +31,6 @@
           {% endfor %}
         </fieldset>
         <div class="row">
-          {% if error %}
-          <div class="alert alert-danger" role="alert">{{ error }}</div>
-          {% endif %}
           <div class="col-md-2">
             <a href="{{ url_for('admin:list', identity=model_view.identity) }}" class="btn">
               Cancel

--- a/sqladmin/templates/edit.html
+++ b/sqladmin/templates/edit.html
@@ -8,6 +8,11 @@
     <div class="card-body border-bottom py-3">
       <form action="{{ model_view._build_url_for('admin:edit', request, obj) }}" method="POST"
         enctype="multipart/form-data">
+        <div class="row">
+          {% if error %}
+          <div class="alert alert-danger" role="alert">{{ error }}</div>
+          {% endif %}
+        </div>
         <fieldset class="form-fieldset">
           {% for field in form %}
           <div class="mb-3 form-group row">
@@ -26,9 +31,6 @@
           {% endfor %}
         </fieldset>
         <div class="row">
-          {% if error %}
-          <div class="alert alert-danger" role="alert">{{ error }}</div>
-          {% endif %}
           <div class="col-md-2">
             <a href="{{ url_for('admin:list', identity=model_view.identity) }}" class="btn">
               Cancel


### PR DESCRIPTION
# Issue

In the create and edit templates, error messages under all the fields. This is problematic if your model has many fields that extend beyond the bottom of the window. In that case there is no visible feedback of the error unless you happen to scroll to the bottom.

See discussion here: https://github.com/aminalaee/sqladmin/discussions/706

# Changes

Move error messages to the top of form.

# Screenshot of change

<img width="684" alt="Screenshot 2024-02-05 at 5 36 00 AM" src="https://github.com/aminalaee/sqladmin/assets/1310468/01c2be65-f831-4afc-be28-8d508ef0c051">
