### PR TITLE
fix: hide items within categories, hide empty categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ examples/
 .uploads
 test.db
 coverage.xml
+/.idea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ ignore_missing_imports = true
 show_error_codes = true
 
 [tool.ruff]
-select = ["E", "F", "I"]
+lint.select = ["E", "F", "I"]
 
 [tool.coverage.run]
 source_pkgs = [

--- a/sqladmin/_menu.py
+++ b/sqladmin/_menu.py
@@ -45,6 +45,12 @@ class CategoryMenu(ItemMenu):
             c.is_active(request) and c.is_accessible(request) for c in self.children
         )
 
+    def is_visible(self, request: Request) -> bool:
+        return any(c.is_visible(request) for c in self.children)
+
+    def is_accessible(self, request: Request) -> bool:
+        return any(c.is_accessible(request) for c in self.children)
+
     @property
     def type_(self) -> str:
         return "Category"

--- a/sqladmin/templates/_macros.html
+++ b/sqladmin/templates/_macros.html
@@ -1,8 +1,7 @@
 {% macro menu_category(menu, request) %}
 {% if menu.is_visible(request) and menu.is_accessible(request) %}
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle {% if menu.is_active(request) %}active{% endif %}" data-bs-toggle="dropdown"
-    href="#">
+  <a class="nav-link dropdown-toggle {% if menu.is_active(request) %}active{% endif %}" data-bs-toggle="dropdown" href="#">
     <span class="nav-link-icon d-md-none d-lg-inline-block">
       {% if menu.icon %}<i class="{{ menu.icon }}"></i>{% endif %}
     </span>
@@ -12,13 +11,14 @@
     <div class="dropdown-menu-columns">
       <div class="dropdown-menu-column">
         {% for sub_menu in menu.children %}
-        <a class="nav-link ps-lg-3 {% if sub_menu.is_active(request) %}active{% endif %}"
-          href="{{ sub_menu.url(request) }}">
-          <span class="nav-link-icon d-md-none d-lg-inline-block">
-            {% if sub_menu.icon %}<i class="{{ sub_menu.icon }}"></i>{% endif %}
-          </span>
-          <span class="nav-link-title">{{ sub_menu.display_name }}</span>
-        </a>
+          {% if sub_menu.is_visible(request) and sub_menu.is_accessible(request) %}
+            <a class="nav-link ps-lg-3 {% if sub_menu.is_active(request) %}active{% endif %}" href="{{ sub_menu.url(request) }}">
+              <span class="nav-link-icon d-md-none d-lg-inline-block">
+                {% if sub_menu.icon %}<i class="{{ sub_menu.icon }}"></i>{% endif %}
+              </span>
+              <span class="nav-link-title">{{ sub_menu.display_name }}</span>
+            </a>
+          {% endif %}
         {% endfor %}
       </div>
     </div>

--- a/tests/test_templates/conftest.py
+++ b/tests/test_templates/conftest.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import jinja2
+import pytest
+from starlette.datastructures import Headers
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Router
+
+
+async def _dummy_method(*args, **kwargs) -> Response:
+    return Response('okay')
+
+
+@pytest.fixture()
+def templates_path() -> Path:
+    return Path(__file__).parent.parent.parent / 'sqladmin' / 'templates'
+
+
+@pytest.fixture()
+def resources_path(request_without_access: Request) -> Path:
+    return Path(__file__).parent / 'resources'
+
+
+@pytest.fixture()
+def jinja_env(templates_path: Path) -> jinja2.Environment:
+    loader = jinja2.FileSystemLoader(templates_path)
+    return jinja2.Environment(loader=loader, autoescape=True, enable_async=True)
+
+
+@pytest.fixture()
+def macros_content(templates_path: Path) -> str:
+    with open(templates_path / '_macros.html') as macros:
+        return macros.read()
+
+
+@pytest.fixture()
+def request_without_access() -> Request:
+    router = Router()
+    router.add_route('/{identity}/list', _dummy_method, ['GET'], name='admin:list')
+
+    return Request({
+        'type': 'http',
+        'router': router,
+        'headers': Headers(),
+    })
+
+
+@pytest.fixture()
+def request_with_access(request_without_access: Request) -> Request:
+    request_without_access.scope['show_hidden'] = True
+    return request_without_access

--- a/tests/test_templates/conftest.py
+++ b/tests/test_templates/conftest.py
@@ -8,10 +8,6 @@ from starlette.responses import Response
 from starlette.routing import Router
 
 
-async def _dummy_method(*args, **kwargs) -> Response:
-    return Response("okay")
-
-
 @pytest.fixture()
 def templates_path() -> Path:
     return Path(__file__).parent.parent.parent / "sqladmin" / "templates"
@@ -37,7 +33,12 @@ def macros_content(templates_path: Path) -> str:
 @pytest.fixture()
 def request_without_access() -> Request:
     router = Router()
-    router.add_route("/{identity}/list", _dummy_method, ["GET"], name="admin:list")
+    router.add_route(
+        "/{identity}/list",
+        lambda request: Response("okay"),
+        ["GET"],
+        name="admin:list",
+    )
 
     return Request(
         {

--- a/tests/test_templates/conftest.py
+++ b/tests/test_templates/conftest.py
@@ -9,17 +9,17 @@ from starlette.routing import Router
 
 
 async def _dummy_method(*args, **kwargs) -> Response:
-    return Response('okay')
+    return Response("okay")
 
 
 @pytest.fixture()
 def templates_path() -> Path:
-    return Path(__file__).parent.parent.parent / 'sqladmin' / 'templates'
+    return Path(__file__).parent.parent.parent / "sqladmin" / "templates"
 
 
 @pytest.fixture()
 def resources_path(request_without_access: Request) -> Path:
-    return Path(__file__).parent / 'resources'
+    return Path(__file__).parent / "resources"
 
 
 @pytest.fixture()
@@ -30,23 +30,25 @@ def jinja_env(templates_path: Path) -> jinja2.Environment:
 
 @pytest.fixture()
 def macros_content(templates_path: Path) -> str:
-    with open(templates_path / '_macros.html') as macros:
+    with open(templates_path / "_macros.html") as macros:
         return macros.read()
 
 
 @pytest.fixture()
 def request_without_access() -> Request:
     router = Router()
-    router.add_route('/{identity}/list', _dummy_method, ['GET'], name='admin:list')
+    router.add_route("/{identity}/list", _dummy_method, ["GET"], name="admin:list")
 
-    return Request({
-        'type': 'http',
-        'router': router,
-        'headers': Headers(),
-    })
+    return Request(
+        {
+            "type": "http",
+            "router": router,
+            "headers": Headers(),
+        }
+    )
 
 
 @pytest.fixture()
 def request_with_access(request_without_access: Request) -> Request:
-    request_without_access.scope['show_hidden'] = True
+    request_without_access.scope["show_hidden"] = True
     return request_without_access

--- a/tests/test_templates/resources/empty-menu.html
+++ b/tests/test_templates/resources/empty-menu.html
@@ -1,0 +1,2 @@
+<div class="navbar-nav">
+</div>

--- a/tests/test_templates/resources/menu-with-one-category.html
+++ b/tests/test_templates/resources/menu-with-one-category.html
@@ -1,0 +1,18 @@
+<div class="navbar-nav">
+    <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle " data-bs-toggle="dropdown" href="#">
+            <span class="nav-link-icon d-md-none d-lg-inline-block"> </span>
+            <span class="nav-link-title">category</span>
+        </a>
+        <div class="dropdown-menu show">
+            <div class="dropdown-menu-columns">
+                <div class="dropdown-menu-column">
+                    <a class="nav-link ps-lg-3 " href="http:///user/list">
+                        <span class="nav-link-icon d-md-none d-lg-inline-block"> </span>
+                        <span class="nav-link-title">Users</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </li>
+</div>

--- a/tests/test_templates/test_menu.py
+++ b/tests/test_templates/test_menu.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import jinja2
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import declarative_base
+from starlette.requests import Request
+
+from sqladmin import ModelView
+from sqladmin._menu import CategoryMenu, Menu, ViewMenu
+
+Base = declarative_base()  # type: ignore
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class UserAdmin(ModelView, model=User):
+    def is_visible(self, request: Request) -> bool:
+        return request.scope.get('show_hidden', False)
+
+    def is_accessible(self, request: Request) -> bool:
+        return request.scope.get('show_hidden', False)
+
+
+def clear_whitespace(input_str: str) -> str:
+    return ' '.join(input_str.split())
+
+
+def test_category_menu_without_access(
+    jinja_env: jinja2.Environment,
+    macros_content: str,
+    request_without_access: Request,
+    resources_path: Path,
+):
+    category_menu = CategoryMenu(name='category')
+    child_item = ViewMenu(view=UserAdmin(), name='view')
+    category_menu.add_child(child_item)
+
+    assert child_item.is_visible(request_without_access) is False
+    assert category_menu.is_visible(request_without_access) is False
+
+    menu = Menu()
+    menu.add(category_menu)
+
+    tpl = jinja_env.from_string(macros_content + '{{ display_menu(menu, request) }}')
+    render = tpl.render(menu=menu, request=request_without_access)
+    expected = (resources_path / 'empty-menu.html').read_text()
+    assert clear_whitespace(render) == clear_whitespace(expected)
+
+
+def test_category_menu_with_access(
+    jinja_env: jinja2.Environment,
+    macros_content: str,
+    request_with_access: Request,
+    resources_path: Path,
+):
+    category_menu = CategoryMenu(name='category')
+    child_item = ViewMenu(view=UserAdmin(), name='view')
+    category_menu.add_child(child_item)
+
+    assert child_item.is_visible(request_with_access) is True
+    assert category_menu.is_visible(request_with_access) is True
+
+    menu = Menu()
+    menu.add(category_menu)
+
+    tpl = jinja_env.from_string(macros_content + '{{ display_menu(menu, request) }}')
+    render = tpl.render(menu=menu, request=request_with_access)
+    expected = (resources_path / 'menu-with-one-category.html').read_text()
+    assert clear_whitespace(render) == clear_whitespace(expected)

--- a/tests/test_templates/test_menu.py
+++ b/tests/test_templates/test_menu.py
@@ -12,7 +12,7 @@ Base = declarative_base()  # type: ignore
 
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
 
     id = Column(Integer, primary_key=True)
     name = Column(String)
@@ -20,14 +20,14 @@ class User(Base):
 
 class UserAdmin(ModelView, model=User):
     def is_visible(self, request: Request) -> bool:
-        return request.scope.get('show_hidden', False)
+        return request.scope.get("show_hidden", False)
 
     def is_accessible(self, request: Request) -> bool:
-        return request.scope.get('show_hidden', False)
+        return request.scope.get("show_hidden", False)
 
 
 def clear_whitespace(input_str: str) -> str:
-    return ' '.join(input_str.split())
+    return " ".join(input_str.split())
 
 
 def test_category_menu_without_access(
@@ -36,8 +36,8 @@ def test_category_menu_without_access(
     request_without_access: Request,
     resources_path: Path,
 ):
-    category_menu = CategoryMenu(name='category')
-    child_item = ViewMenu(view=UserAdmin(), name='view')
+    category_menu = CategoryMenu(name="category")
+    child_item = ViewMenu(view=UserAdmin(), name="view")
     category_menu.add_child(child_item)
 
     assert child_item.is_visible(request_without_access) is False
@@ -46,9 +46,9 @@ def test_category_menu_without_access(
     menu = Menu()
     menu.add(category_menu)
 
-    tpl = jinja_env.from_string(macros_content + '{{ display_menu(menu, request) }}')
+    tpl = jinja_env.from_string(macros_content + "{{ display_menu(menu, request) }}")
     render = tpl.render(menu=menu, request=request_without_access)
-    expected = (resources_path / 'empty-menu.html').read_text()
+    expected = (resources_path / "empty-menu.html").read_text()
     assert clear_whitespace(render) == clear_whitespace(expected)
 
 
@@ -58,8 +58,8 @@ def test_category_menu_with_access(
     request_with_access: Request,
     resources_path: Path,
 ):
-    category_menu = CategoryMenu(name='category')
-    child_item = ViewMenu(view=UserAdmin(), name='view')
+    category_menu = CategoryMenu(name="category")
+    child_item = ViewMenu(view=UserAdmin(), name="view")
     category_menu.add_child(child_item)
 
     assert child_item.is_visible(request_with_access) is True
@@ -68,7 +68,7 @@ def test_category_menu_with_access(
     menu = Menu()
     menu.add(category_menu)
 
-    tpl = jinja_env.from_string(macros_content + '{{ display_menu(menu, request) }}')
+    tpl = jinja_env.from_string(macros_content + "{{ display_menu(menu, request) }}")
     render = tpl.render(menu=menu, request=request_with_access)
-    expected = (resources_path / 'menu-with-one-category.html').read_text()
+    expected = (resources_path / "menu-with-one-category.html").read_text()
     assert clear_whitespace(render) == clear_whitespace(expected)


### PR DESCRIPTION
This pull-request fixes #708 issue

Breafly:
If a menu item is added to a category, it wouldn't be hidden, even if `is_visible` function returns `False`
This pull-request fixes it
Also, if a category contains invisible items only, it would be hidden as well