### PR TITLE
Hide save and add another button from edit.html if can_create is False

### DIFF
--- a/sqladmin/templates/edit.html
+++ b/sqladmin/templates/edit.html
@@ -43,10 +43,12 @@
             <div class="btn-group flex-wrap" data-toggle="buttons">
               <input type="submit" name="save" value="Save" class="btn">
               <input type="submit" name="save" value="Save and continue editing" class="btn">
-              {% if model_view.save_as %}
-              <input type="submit" name="save" value="Save as new" class="btn">
-              {% else %}
-              <input type="submit" name="save" value="Save and add another" class="btn">
+              {% if model_view.can_create %}
+                {% if model_view.save_as %}
+                <input type="submit" name="save" value="Save as new" class="btn">
+                {% else %}
+                <input type="submit" name="save" value="Save and add another" class="btn">
+                {% endif %}
               {% endif %}
             </div>
           </div>


### PR DESCRIPTION
Fixed an issue where buttons for creating new items were still shown even when can_create was set to False, leading to a 403 error if clicked.