### PR TITLE
Validate page and pageSize query parameters

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -440,6 +440,14 @@ class Admin(BaseAdminView):
         pagination = await model_view.list(request)
         pagination.add_pagination_urls(request.url)
 
+        if (
+            pagination.page * pagination.page_size
+            > pagination.count + pagination.page_size
+        ):
+            raise HTTPException(
+                status_code=400, detail="Invalid page or pageSize parameter"
+            )
+
         context = {"model_view": model_view, "pagination": pagination}
         return await self.templates.TemplateResponse(
             request, model_view.list_template, context

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -688,7 +688,6 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         self._custom_actions_in_detail: Dict[str, str] = {}
         self._custom_actions_confirmation: Dict[str, str] = {}
 
-
     def _run_query_sync(self, stmt: ClauseElement) -> Any:
         with self.session_maker(expire_on_commit=False) as session:
             result = session.execute(stmt)
@@ -747,10 +746,10 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
 
         return value
 
-    def validate_page_number(self, page_number: str|None, default: int) -> int:
+    def validate_page_number(self, page_number: str | None, default: int) -> int:
         if page_number is None:
             return default
-        
+
         try:
             return int(page_number)
         except ValueError:

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -746,7 +746,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
 
         return value
 
-    def validate_page_number(self, page_number: str | None, default: int) -> int:
+    def validate_page_number(self, page_number: Union[str, None], default: int) -> int:
         if page_number is None:
             return default
 

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -194,7 +194,7 @@
         Show
         <a href="#" class="btn btn-sm btn-light dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="false">
-          {{ model_view.validate_page_number((request.query_params.get("pageSize") or model_view.page_size),model_view.page_size)  }} / Page
+          {{ request.query_params.get("pageSize") or model_view.page_size }} / Page
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -194,7 +194,7 @@
         Show
         <a href="#" class="btn btn-sm btn-light dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="false">
-          {{ model_view.page_size_ }} / Page
+          {{ model_view.validate_page_number((request.query_params.get("pageSize") or model_view.page_size),model_view.page_size)  }} / Page
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -194,7 +194,7 @@
         Show
         <a href="#" class="btn btn-sm btn-light dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="false">
-          {{ request.query_params.get("pageSize") or model_view.page_size }} / Page
+          {{ model_view.page_size_ }} / Page
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}


### PR DESCRIPTION
For page and Pagesize query paramter , Set the default value when it contain non integer value .

Fix issue: #751 

Page and PageSize set to default value when called as 
https:domainname/admin/address/list?page=somevalue
https:domainname/admin/address/list?page=2&pageSize=somevalue

and
when called as  
https:domainname/admin/address/list?page=num 
https:domainname/admin/address/list?pageSize=num
where num lies in  (0,-1,-2...)
here, page and pagesize take only positive integer
