### PR TITLE
Fix page number issue when changing page size

### DIFF
--- a/sqladmin/pagination.py
+++ b/sqladmin/pagination.py
@@ -46,6 +46,9 @@ class Pagination:
 
         raise RuntimeError("Next page not found.")
 
+    def new_page_number(self, new_page_size) -> int:
+        return (self.page - 1) * self.page_size // new_page_size + 1
+
     def add_pagination_urls(self, base_url: URL) -> None:
         # Previous pages
         for p in range(self.page - min(self.max_page_controls, 3), self.page):

--- a/sqladmin/pagination.py
+++ b/sqladmin/pagination.py
@@ -46,8 +46,10 @@ class Pagination:
 
         raise RuntimeError("Next page not found.")
 
-    def new_page_number(self, new_page_size) -> int:
-        return (self.page - 1) * self.page_size // new_page_size + 1
+    def resize(self, page_size: int) -> Pagination:
+        self.page = (self.page - 1) * self.page_size // page_size + 1
+        self.page_size = page_size
+        return self
 
     def add_pagination_urls(self, base_url: URL) -> None:
         # Previous pages

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -198,7 +198,7 @@
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}
-          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option,page=pagination.new_page_number(page_size_option)) }}">
+          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option,page=pagination.resize(page_size_option)).page }}">
             {{ page_size_option }} / Page
           </a>
           {% endfor %}

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -198,7 +198,7 @@
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}
-          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option,page=((pagination.page - 1) * pagination.page_size // page_size_option + 1)}}">
+          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option,page=((pagination.page - 1) * pagination.page_size // page_size_option + 1))}}">
             {{ page_size_option }} / Page
           </a>
           {% endfor %}

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -198,7 +198,7 @@
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}
-          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option) }}">
+          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option,page=((pagination.page - 1) * pagination.page_size // page_size_option + 1)}}">
             {{ page_size_option }} / Page
           </a>
           {% endfor %}

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -198,7 +198,7 @@
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}
-          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option,page=pagination.resize(page_size_option)).page }}">
+          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option, page=pagination.resize(page_size_option).page) }}">
             {{ page_size_option }} / Page
           </a>
           {% endfor %}

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -198,7 +198,7 @@
         </a>
         <div class="dropdown-menu">
           {% for page_size_option in model_view.page_size_options %}
-          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option,page=((pagination.page - 1) * pagination.page_size // page_size_option + 1))}}">
+          <a class="dropdown-item" href="{{ request.url.include_query_params(pageSize=page_size_option,page=pagination.new_page_number(page_size_option)) }}">
             {{ page_size_option }} / Page
           </a>
           {% endfor %}

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -74,9 +74,12 @@ def test_multi_page_unequal_previous_and_next() -> None:
     assert pagination.page_controls == page_controls
 
 
-def test_new_page_number() -> None:
+def test_resize_pagination() -> None:
     pagination = Pagination(rows=[], page=3, page_size=5, count=20)
+    assert pagination.resize(100).page == 1
 
-    assert pagination.new_page_number(100) == 1
-    assert pagination.new_page_number(1) == 11
-    assert pagination.new_page_number(8) == 2
+    pagination = Pagination(rows=[], page=3, page_size=5, count=20)
+    assert pagination.resize(1).page == 11
+
+    pagination = Pagination(rows=[], page=3, page_size=5, count=20)
+    assert pagination.resize(8).page == 2

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -73,10 +73,10 @@ def test_multi_page_unequal_previous_and_next() -> None:
 
     assert pagination.page_controls == page_controls
 
+
 def test_new_page_number() -> None:
     pagination = Pagination(rows=[], page=3, page_size=5, count=20)
 
     assert pagination.new_page_number(100) == 1
     assert pagination.new_page_number(1) == 11
     assert pagination.new_page_number(8) == 2
-

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -72,3 +72,11 @@ def test_multi_page_unequal_previous_and_next() -> None:
     ]
 
     assert pagination.page_controls == page_controls
+
+def test_new_page_number() -> None:
+    pagination = Pagination(rows=[], page=3, page_size=5, count=20)
+
+    assert pagination.new_page_number(100) == 1
+    assert pagination.new_page_number(1) == 11
+    assert pagination.new_page_number(8) == 2
+


### PR DESCRIPTION
fixes #781

New page is calculated as `((currentPage - 1) * pageSize // newPageSize) + 1` such that user will be taken to new page which has the first entry of currentPage visible.