### PR TITLE
feat: use favicon_url instead of logo_url for favicon

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -68,6 +68,7 @@ class BaseAdmin:
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str | None = None,
+        favicon_url: str | None = None,
         templates_dir: str = "templates",
         middlewares: Sequence[Middleware] | None = None,
         authentication_backend: AuthenticationBackend | None = None,
@@ -78,6 +79,7 @@ class BaseAdmin:
         self.templates_dir = templates_dir
         self.title = title
         self.logo_url = logo_url
+        self.favicon_url = favicon_url
 
         if session_maker:
             self.session_maker = session_maker
@@ -340,6 +342,7 @@ class Admin(BaseAdminView):
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str | None = None,
+        favicon_url: str | None = None,
         middlewares: Sequence[Middleware] | None = None,
         debug: bool = False,
         templates_dir: str = "templates",
@@ -353,6 +356,7 @@ class Admin(BaseAdminView):
             base_url: Base URL for Admin interface.
             title: Admin title.
             logo_url: URL of logo to be displayed instead of title.
+            favicon_url: URL of favicon to be displayed.
         """
 
         super().__init__(
@@ -362,6 +366,7 @@ class Admin(BaseAdminView):
             base_url=base_url,
             title=title,
             logo_url=logo_url,
+            favicon_url=favicon_url,
             templates_dir=templates_dir,
             middlewares=middlewares,
             authentication_backend=authentication_backend,

--- a/sqladmin/templates/sqladmin/base.html
+++ b/sqladmin/templates/sqladmin/base.html
@@ -10,8 +10,8 @@
   <link rel="stylesheet" href="{{ url_for('admin:statics', path='css/select2.min.css') }}">
   <link rel="stylesheet" href="{{ url_for('admin:statics', path='css/flatpickr.min.css') }}">
   <link rel="stylesheet" href="{{ url_for('admin:statics', path='css/main.css') }}">
-  {% if admin.logo_url %}
-    <link rel="icon" href="{{ admin.logo_url}}"/>
+  {% if admin.favicon_url %}
+  <link rel="icon" href="{{ admin.favicon_url }}">
   {% endif %}
   {% block head %}
   {% endblock %}


### PR DESCRIPTION
Hello everyone,

I recently started using sqladmin and I need to add a favicon.

I saw this merged PR #787 and I noticed that the same variable is used for both the logo and the favicon.

I updated the Admin definition so it accepts a `favicon_url`, and updated the base template.

Note: I followed the contribution guide, but have been unable to run the hatch commands locally. I am getting this error:

```sh
$ hatch run lint
/bin/sh: line 1: lint: command not found
```

I tried using other commands and subcommands  (`hatch run lint.check`) but I get the same result.

Edit: I see the commands were successful on github actions