### PR TITLE
fix: clamp page if it exceeds the maximum page

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -442,12 +442,13 @@ class Admin(BaseAdminView):
         pagination = await model_view.list(request)
         pagination.add_pagination_urls(request.url)
 
-        if (
-            pagination.page * pagination.page_size
-            > pagination.count + pagination.page_size
-        ):
-            raise HTTPException(
-                status_code=400, detail="Invalid page or pageSize parameter"
+        request_page = model_view.validate_page_number(
+            request.query_params.get("page"), 1
+        )
+
+        if request_page > pagination.page:
+            return RedirectResponse(
+                request.url.include_query_params(page=pagination.page), status_code=302
             )
 
         context = {"model_view": model_view, "pagination": pagination}

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -810,6 +810,9 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         else:
             count = await self.count(request)
 
+        # Clamp page
+        page = min(page, max(1, count // page_size + 1))
+
         stmt = stmt.limit(page_size).offset((page - 1) * page_size)
         rows = await self._run_query(stmt)
 

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -810,9 +810,6 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         else:
             count = await self.count(request)
 
-        # Clamp page
-        page = min(page, max(1, count // page_size + 1))
-
         stmt = stmt.limit(page_size).offset((page - 1) * page_size)
         rows = await self._run_query(stmt)
 

--- a/sqladmin/pagination.py
+++ b/sqladmin/pagination.py
@@ -46,15 +46,16 @@ class Pagination:
 
         raise RuntimeError("Next page not found.")
 
+    def __post_init__(self):
+        # Clamp page
+        self.page = min(self.page, max(1, self.count // self.page_size + 1))
+
     def resize(self, page_size: int) -> Pagination:
         self.page = (self.page - 1) * self.page_size // page_size + 1
         self.page_size = page_size
         return self
 
     def add_pagination_urls(self, base_url: URL) -> None:
-        # Clamp page
-        self.page = min(self.page, max(1, self.count // self.page_size + 1))
-
         # Previous pages
         for p in range(self.page - min(self.max_page_controls, 3), self.page):
             if p > 0:

--- a/sqladmin/pagination.py
+++ b/sqladmin/pagination.py
@@ -52,6 +52,9 @@ class Pagination:
         return self
 
     def add_pagination_urls(self, base_url: URL) -> None:
+        # Clamp page
+        self.page = min(self.page, max(1, self.count // self.page_size + 1))
+
         # Previous pages
         for p in range(self.page - min(self.max_page_controls, 3), self.page):
             if p > 0:

--- a/sqladmin/pagination.py
+++ b/sqladmin/pagination.py
@@ -46,7 +46,7 @@ class Pagination:
 
         raise RuntimeError("Next page not found.")
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Clamp page
         self.page = min(self.page, max(1, self.count // self.page_size + 1))
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -177,7 +177,7 @@ def test_validate_page_and_page_size():
     client = TestClient(app)
 
     response = client.get("/admin/user/list?page=10000")
-    assert response.status_code == 400
+    assert response.status_code == 200
 
     response = client.get("/admin/user/list?page=aaaa")
     assert response.status_code == 400


### PR DESCRIPTION
Hello,

This change was asked by a client complaining about the error when filtering and being on a high page. 

Imagine we have 200 rows to display. The `page_size` is 10, hence the maximum page we should access is 20.

Now imagine that we want to filter out some of the rows, using the `search` parameter. After the search, there are 100 rows to display only, so the new maximum page is 10.

This parameter is applied after typing, and the current page parameter does not change. If we are in a page greater than the new maximum, we will be prompted with the error             

```py
raise HTTPException(
                status_code=400, detail="Invalid page or pageSize parameter"
            )
```

This seems like unintended behaviour to me. In my view, trying to access a page higher than the max in this situation should not trigger an error, but instead display the last page of them all. 

This PR clamps the page to its maximum value if possible. 

There is a caveat: the url displays the page that you specified, even though the UI will show the max page. so for example, the URL could be:

http://my-app/admin/some-item/list?search=someval&page=15

But the UI would show that we are on page 10.
