### PR TITLE
fix: handle pagination issue when search results do not match current…

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -803,18 +803,21 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
             stmt = stmt.options(selectinload(relation))
 
         stmt = self.sort_query(stmt, request)
-        
+
         if search:
             stmt = self.search_query(stmt=stmt, term=search)
             count = await self.count(request, select(func.count()).select_from(stmt))
         else:
             count = await self.count(request)
 
-        max_pages = (count + page_size - 1) // page_size
+        if count > 0:
+            max_pages = (count + page_size - 1) // page_size
+        else:
+            max_pages = 1
 
-        if page > max_pages and count >= 0:
+        if page > max_pages:
             page = 1
-        
+
         stmt = stmt.limit(page_size).offset((page - 1) * page_size)
         rows = await self._run_query(stmt)
 

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -803,13 +803,18 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
             stmt = stmt.options(selectinload(relation))
 
         stmt = self.sort_query(stmt, request)
-
+        
         if search:
             stmt = self.search_query(stmt=stmt, term=search)
             count = await self.count(request, select(func.count()).select_from(stmt))
         else:
             count = await self.count(request)
 
+        max_pages = (count + page_size - 1) // page_size
+
+        if page > max_pages and count >= 0:
+            page = 1
+        
         stmt = stmt.limit(page_size).offset((page - 1) * page_size)
         rows = await self._run_query(stmt)
 


### PR DESCRIPTION
### Description

This PR fixes a pagination issue in SQLAdmin where performing a search from a page other than the first page would result in an error (“Invalid page or pageSize parameter”) if the search results had fewer pages than the current page.

### Changes
- Added logic to check the total number of pages after performing a search.
- If the current page exceeds the total available pages in the search results, the user is automatically redirected to the first page.
- This ensures smooth user experience when navigating between search results and pagination.

### Testing
- Verified that search works correctly when on different pages of the pagination.
- Verified that the user is correctly redirected to the first page if the current page number exceeds the available pages in the search results.