### PR TITLE
fix: deletion doesn't work

### DIFF
--- a/sqladmin/_queries.py
+++ b/sqladmin/_queries.py
@@ -174,7 +174,7 @@ class Query:
 
     def _delete_sync(self, pk: str, request: Request) -> None:
         with self.model_view.session_maker() as session:
-            obj = session.execute(self._get_delete_stmt(pk)).scalar_one_or_none()
+            obj = session.execute(self._get_delete_stmt(pk)).unique().scalar_one_or_none()
             anyio.from_thread.run(self.model_view.on_model_delete, obj, request)
             session.delete(obj)
             session.commit()


### PR DESCRIPTION
I got this error:

```
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqladmin/_queries.py", line 177, in _delete_sync
    obj = session.execute(self._get_delete_stmt(pk)).scalar_one_or_none()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 1485, in scalar_one_or_none
    return self._only_one_row(
           ^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 776, in _only_one_row
    existing_row_hash = strategy(row) if strategy else row
                        ^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqlalchemy/orm/loading.py", line 285, in require_unique
    raise sa_exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: The unique() method must be invoked on this Result, as it contains results that include joined eager loads against collections
```

I simply did what it said, and it worked. There might be bigger implications to this problem, but that solved it for me.
Would love to see it merged!

<details> <summary> Full Stack Trace </summary>

```
Traceback (most recent call last):
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 401, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 185, in __call__
    with collapse_excgroups():
  File "/nix/store/flkpbg20pfzfa9f2lwzrzjl718i2ccw7-python3-3.11.7/lib/python3.11/contextlib.py", line 158, in __exit__
    self.gen.throw(typ, value, traceback)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 188, in __call__
    await response(scope, wrapped_receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 222, in __call__
    async for chunk in self.body_iterator:
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 179, in body_stream
    raise app_exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 149, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/sessions.py", line 85, in __call__
    await self.app(scope, receive, send_wrapper)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 185, in __call__
    with collapse_excgroups():
  File "/nix/store/flkpbg20pfzfa9f2lwzrzjl718i2ccw7-python3-3.11.7/lib/python3.11/contextlib.py", line 158, in __exit__
    self.gen.throw(typ, value, traceback)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 188, in __call__
    await response(scope, wrapped_receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 222, in __call__
    async for chunk in self.body_iterator:
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 179, in body_stream
    raise app_exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 149, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
    raise exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
    await app(scope, receive, sender)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/routing.py", line 460, in handle
    await self.app(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/sessions.py", line 85, in __call__
    await self.app(scope, receive, send_wrapper)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
    raise exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
    await app(scope, receive, sender)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
    raise exc
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
    await app(scope, receive, sender)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqladmin/authentication.py", line 68, in wrapper_decorator
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqladmin/application.py", line 497, in delete
    await model_view.delete_model(request, pk)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqladmin/models.py", line 1001, in delete_model
    await Query(self).unique.delete(pk, request)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqladmin/_queries.py", line 222, in delete
    await anyio.to_thread.run_sync(self._delete_sync, obj, request)
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 2461, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 962, in run
    result = context.run(func, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqladmin/_queries.py", line 177, in _delete_sync
    obj = session.execute(self._get_delete_stmt(pk)).scalar_one_or_none()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 1485, in scalar_one_or_none
    return self._only_one_row(
           ^^^^^^^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 776, in _only_one_row
    existing_row_hash = strategy(row) if strategy else row
                        ^^^^^^^^^^^^^
  File "<my_repo_path>/.venv/lib/python3.11/site-packages/sqlalchemy/orm/loading.py", line 285, in require_unique
    raise sa_exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: The unique() method must be invoked on this Result, as it contains results that include joined eager loads against collections
```

</details>