### PR TITLE
fix: use children.extend in Menu.add

### DIFF
--- a/sqladmin/_menu.py
+++ b/sqladmin/_menu.py
@@ -93,6 +93,6 @@ class Menu:
         # Only works for one-level menu
         for root in self.items:
             if root.name == item.name:
-                root.children.append(*item.children)
+                root.children.extend(item.children)
                 return
         self.items.append(item)


### PR DESCRIPTION
Hi, I just started using this library via Litestar's plugin and I ran into an issue that only occurred when I was running tests of my application. When I have used the app normally then I could not get this error.

The error: 

```
>               root.children.append(*item.children)
E               TypeError: list.append() takes exactly one argument (0 given)
```

It's raised when `children` are an empty list. Fix was easy, so I hope it's not expected that at that point `children` aren't empty, but if it was so, then probably a nicer error should be raised.