### PR TITLE
Allow custom response in authentication logout

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,7 +10,7 @@ The class `AuthenticationBackend` has three methods you need to override:
 
 * `authenticate`: Will be called for validating each incoming request.
 * `login`: Will be called only in the login page to validate username/password.
-* `logout`: Will be called only for the logout, usually clearin the session.
+* `logout`: Will be called only for the logout, usually clearing the session.
 
 ```python
 from sqladmin import Admin

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -638,7 +638,11 @@ class Admin(BaseAdminView):
     async def logout(self, request: Request) -> Response:
         assert self.authentication_backend is not None
 
-        await self.authentication_backend.logout(request)
+        response = await self.authentication_backend.logout(request)
+
+        if isinstance(response, Response):
+            return response
+
         return RedirectResponse(request.url_for("admin:index"), status_code=302)
 
     async def ajax_lookup(self, request: Request) -> Response:

--- a/sqladmin/authentication.py
+++ b/sqladmin/authentication.py
@@ -40,7 +40,7 @@ class AuthenticationBackend:
         This method will be called for each incoming request
         to validate the authentication.
 
-        If a 'Response' or `RedirectResponse` is returned,
+        If a `Response` or `RedirectResponse` is returned,
         that response is returned to the user,
         otherwise a True/False is expected.
         """

--- a/sqladmin/authentication.py
+++ b/sqladmin/authentication.py
@@ -29,9 +29,13 @@ class AuthenticationBackend:
         """
         raise NotImplementedError()
 
-    async def logout(self, request: Request) -> bool:
+    async def logout(self, request: Request) -> Response | bool:
         """Implement logout logic here.
         This will usually clear the session with `request.session.clear()`.
+
+        If a `Response` or `RedirectResponse` is returned,
+        that response is returned to the user,
+        otherwise the user will be redirected to the index page.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
This pull request introduces the ability to return a custom response for the logout method in an authentication backend.
The current behavior is that the user simply gets redirected to the index page after the logout method is called. However, the current behavior does not allow for custom redirects, or manipulation of the response object, such as deletion of cookies (which might be used in some authentication scenarios). This PR overcomes this limitation.

I also took the opportunity to fix a couple of typos and docstring inconsistencies.

### Authentication system changes:

* **Updated logout behavior in `sqladmin/application.py`:** The `logout` method now checks if the `AuthenticationBackend.logout` method returns a `Response` and directly returns it if applicable. This allows custom responses during logout. This functionality is now analogous to how the return of `authenticate` is dealt with.

* **Adjusted method signature in `sqladmin/authentication.py`:** To accomodate the above, the `logout` method's return type is updated to `Response | bool`, allowing it to return either a response object or a boolean.

### Documentation updates:

* **Adjusted docstring for `logout` method:** To document above functionality, the docstring of the method is updated accordingly, so that API reference docs reflect the changes.

* **Improved type clarity in `authenticate` method:** Corrected the documentation for the `authenticate` method to use backticks consistently for `Response` and `RedirectResponse`, ensuring consistency across.

* **Fixed typo in `docs/authentication.md`:** Corrected a typo in the description of the `logout` method, changing "clearin" to "clearing."