### PR TITLE
fix: CategoryMenu is_active logic

### DIFF
--- a/sqladmin/_menu.py
+++ b/sqladmin/_menu.py
@@ -44,7 +44,7 @@ class ItemMenu:
 class CategoryMenu(ItemMenu):
     def is_active(self, request: Request) -> bool:
         return any(
-            c.is_visible(request) and c.is_accessible(request) for c in self.children
+            c.is_active(request) and c.is_accessible(request) for c in self.children
         )
 
     @property

--- a/sqladmin/templates/sqladmin/_macros.html
+++ b/sqladmin/templates/sqladmin/_macros.html
@@ -1,5 +1,5 @@
 {% macro menu_category(menu, request) %}
-{% if menu.is_active(request) %}
+{% if menu.is_visible(request) and menu.is_accessible(request) %}
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle {% if menu.is_active(request) %}active{% endif %}" data-bs-toggle="dropdown"
     href="#">

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -42,6 +42,32 @@ def test_category_menu():
     assert item_menu.type_ == "Category"
 
 
+def test_category_menu_is_active_when_child_is_active():
+    request = Request(
+        {
+            "type": "http",
+            "path_params": {"identity": "user"},
+        }
+    )
+    user_menu = ViewMenu(view=UserAdmin(), name="user")
+
+    category_menu = CategoryMenu(name="Models")
+    category_menu.add_child(user_menu)
+
+    assert user_menu.is_active(request) is True
+    assert category_menu.is_active(request) is True
+
+
+def test_category_menu_is_not_active_when_no_child_is_active():
+    user_menu = ViewMenu(view=UserAdmin(), name="user")
+
+    category_menu = CategoryMenu(name="Models")
+    category_menu.add_child(user_menu)
+
+    assert user_menu.is_active(request) is False
+    assert category_menu.is_active(request) is False
+
+
 def test_view_menu():
     item_menu = ViewMenu(view=UserAdmin(), name="view")
 


### PR DESCRIPTION
A previous PR (https://github.com/aminalaee/sqladmin/pull/698) introduced a bug in the `CategoryMenu.is_active` function, causing it to return `True` if any child elements were visible. This led to misleading template errors, making all categories appear active since they all contain visible children.

This update includes:

* A fix for the `CategoryMenu`.
* Adjustments to the `_menu` macros to ensure categories are displayed not only if they are active but also if they are visible and accessible to the current user.
* Additional tests to prevent regression.