### PR TITLE
customizable identity attribute for ModelView URL generation

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -737,8 +737,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
     def _url_for_delete(self, request: Request, obj: Any) -> str:
         pk = get_object_identifier(obj)
         query_params = urlencode({"pks": pk})
-        url = request.url_for(
-            "admin:delete", identity=self.identity)
+        url = request.url_for("admin:delete", identity=self.identity)
         return str(url) + "?" + query_params
 
     def _url_for_details_with_prop(self, request: Request, obj: Any, prop: str) -> URL:

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -92,7 +92,7 @@ class ModelViewMeta(type):
             )
 
         cls.pk_columns = get_primary_keys(model)
-        cls.identity = slugify_class_name(model.__name__)
+        cls.identity = slugify_class_name(attrs.get("identity", model.__name__))
         cls.model = model
 
         cls.name = attrs.get("name", prettify_class_name(cls.model.__name__))
@@ -738,8 +738,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         pk = get_object_identifier(obj)
         query_params = urlencode({"pks": pk})
         url = request.url_for(
-            "admin:delete", identity=slugify_class_name(obj.__class__.__name__)
-        )
+            "admin:delete", identity=self.identity)
         return str(url) + "?" + query_params
 
     def _url_for_details_with_prop(self, request: Request, obj: Any, prop: str) -> URL:
@@ -754,7 +753,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
     def _build_url_for(self, name: str, request: Request, obj: Any) -> URL:
         return request.url_for(
             name,
-            identity=slugify_class_name(obj.__class__.__name__),
+            identity=self.identity,
             pk=get_object_identifier(obj),
         )
 


### PR DESCRIPTION
Allow specifying a custom 'identity' attribute in ModelViewMeta for URL generation

- Enable using a customizable 'identity' attribute instead of default slugified model class name.
- This allows creating separate ModelView instances for the same model with distinct URLs, improving flexibility and organization.