### PR TITLE
Fix date and time type handling when used as primary key

### DIFF
--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -6,7 +6,7 @@ import os
 import re
 import unicodedata
 from abc import ABC, abstractmethod
-from datetime import timedelta
+from datetime import date, datetime, time, timedelta
 from typing import (
     Any,
     AsyncGenerator,
@@ -226,7 +226,13 @@ def object_identifier_values(id_string: str, model: Any) -> tuple:
     pks = get_primary_keys(model)
     for pk, part in zip(pks, _object_identifier_parts(id_string, model)):
         type_ = get_column_python_type(pk)
-        value = False if type_ is bool and part == "False" else type_(part)
+        value: Any
+        if issubclass(type_, (date, datetime, time)):
+            value = type_.fromisoformat(part)
+        elif issubclass(type_, bool):
+            value = False if part == "False" else type_(part)
+        else:
+            value = type_(part)  # type: ignore [call-arg]
         values.append(value)
     return tuple(values)
 


### PR DESCRIPTION
Some scenarios call for a primary key that includes date or time types.

Fix the resulting exception "TypeError: 'str' object cannot be interpreted as an integer" when calling `object_identifier_values`.
