### PR TITLE
Fix fastapi root path o2m m2m search

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -81,7 +81,7 @@ class BaseAdmin:
         self.favicon_url = favicon_url
 
         if hasattr(self.app, "root_path"):
-            self.base_url = self.app.root_path + base_url
+            self.base_url = urljoin(self.app.root_path + "/", base_url.lstrip("/"))
         else:
             self.base_url = base_url
 


### PR DESCRIPTION
fix the search in one-to-many or many-to-many field if fastapi root_path is set

app = FastAPI(
    root_path="/api",
)
