### PR TITLE
[Feature] Added switch style for checkbox and fixed related bug.

### DIFF
--- a/sqladmin/fields.py
+++ b/sqladmin/fields.py
@@ -389,3 +389,11 @@ class FileField(fields.FileField):
     """
 
     widget = sqladmin_widgets.FileInputWidget()
+
+
+class BooleanField(fields.BooleanField):
+    """
+    Boolean checkbox field.
+    """
+
+    widget = sqladmin_widgets.BooleanInputWidget()

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -26,7 +26,6 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql.elements import Label
 from sqlalchemy.sql.schema import Column
 from wtforms import (
-    BooleanField,
     DecimalField,
     Field,
     Form,
@@ -50,6 +49,7 @@ from sqladmin.exceptions import NoConverterFound
 from sqladmin.fields import (
     AjaxSelectField,
     AjaxSelectMultipleField,
+    BooleanField,
     DateField,
     DateTimeField,
     FileField,
@@ -363,6 +363,7 @@ class ModelConverter(ModelConverterBase):
         if not prop.columns[0].nullable:
             kwargs.setdefault("render_kw", {})
             kwargs["render_kw"]["class"] = "form-check-input"
+            kwargs["validators"].append(validators.InputRequired())
             return BooleanField(**kwargs)
 
         kwargs["allow_blank"] = True

--- a/sqladmin/widgets.py
+++ b/sqladmin/widgets.py
@@ -98,3 +98,22 @@ class FileInputWidget(widgets.FileInput):
             return current_value + checkbox + super().__call__(field, **kwargs)
         else:
             return super().__call__(field, **kwargs)
+
+
+class BooleanInputWidget(widgets.Input):
+    """
+    Render a checkbox.
+
+    The ``checked`` HTML attribute is set if the field's data is a non-false value.
+    """
+
+    input_type = "checkbox"
+
+    def __call__(self, field: Field, **kwargs: Any) -> Markup:
+        kwargs["checked"] = field.object_data
+
+        return Markup(
+            '<div class="form-switch d-flex align-items-center h-100">'
+            + str(Markup.escape(super().__call__(field, **kwargs)))
+            + "</div>"
+        )

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -6,6 +6,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import (
     JSON,
     BigInteger,
+    Boolean,
     Column,
     Date,
     Enum,
@@ -119,6 +120,7 @@ class Product(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
     price = Column(BigInteger)
+    is_sold = Column(Boolean, nullable=False)
 
 
 @pytest.fixture
@@ -490,6 +492,54 @@ async def test_create_endpoint_with_required_fields(client: AsyncClient) -> None
     )
     assert (
         '<label class="form-label col-sm-2 col-form-label" for="price">Price</label>'
+        in response.text
+    )
+
+
+async def test_update_endpoint_with_checkbox_widget(client: AsyncClient) -> None:
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Product(
+                    id=1,
+                    name="RAM",
+                    price=99_999,
+                    is_sold=False,
+                ),
+                Product(
+                    id=2,
+                    name="RAM second",
+                    price=12421,
+                    is_sold=True,
+                ),
+            ]
+        )
+        await session.commit()
+
+    stmt = select(func.count(Product.id))
+    async with session_maker() as s:
+        result = await s.execute(stmt)
+    assert result.scalar_one() == 2
+
+    response = await client.get(f"/admin/{Product.__tablename__}/edit/1")
+
+    assert response.status_code == 200
+
+    assert (
+        '<div class="form-switch d-flex align-items-center h-100">'
+        f'<input class="form-check-input" id="{Product.is_sold.key}" '
+        f'name="{Product.is_sold.key}" required type="checkbox" value="y"></div>'
+        in response.text
+    )
+
+    response = await client.get(f"/admin/{Product.__tablename__}/edit/2")
+
+    assert response.status_code == 200
+
+    assert (
+        '<div class="form-switch d-flex align-items-center h-100">'
+        f'<input checked class="form-check-input" id="{Product.is_sold.key}" '
+        f'name="{Product.is_sold.key}" required type="checkbox" value="y"></div>'
         in response.text
     )
 


### PR DESCRIPTION
## Feature description
Updated the visual presentation of the checkbox. It now appears as a switch.

## Bug description
Also fixed a bug related to the checkbox. The bug was that the checkbox was considered a required field by default, but the required flag was not being passed into the flags list. Because of this, the field was not displayed as mandatory in the admin panel.

# Before
<img width="875" height="464" alt="Screenshot after" src="https://github.com/user-attachments/assets/658f03fc-5286-40e7-948c-15bbbc41dc6c" />

# After
<img width="875" height="464" alt="Screenshot before" src="https://github.com/user-attachments/assets/6498e778-7493-4770-bd1a-1213cb44b7e5" />

## Backward Compatibility
* Compatible with all custom templates.
* Not applied when `form_args.{field_name}.widget` is overridden (e.g., `CustomWidget`).