### PR TITLE
Fix buttons width on details page

### DIFF
--- a/sqladmin/templates/sqladmin/details.html
+++ b/sqladmin/templates/sqladmin/details.html
@@ -48,7 +48,7 @@
         </table>
       </div>
       <div class="card-footer container">
-        <div class="row">
+        <div class="row row-gap-2">
           <div class="col-auto">
             <a href="{{ url_for('admin:list', identity=model_view.identity) }}" class="btn">
               Go Back


### PR DESCRIPTION
**Summary**
This Pull Requests fixes the overlapping of standard buttons and action buttons on top of each other on details page
solution to Issue #895 

**Before**

<img width="1170" height="381" alt="2025-12-20_15-03-35" src="https://github.com/user-attachments/assets/7dc1cbc6-2a2a-4e25-be9c-d7adea06238a" />
<img width="567" height="378" alt="2025-12-20_15-03-49" src="https://github.com/user-attachments/assets/93995375-1e11-4b7c-b123-9f0538540b38" />

**After**

<img width="903" height="382" alt="2025-12-20_16-26-03" src="https://github.com/user-attachments/assets/b6e0b377-2f31-41ac-b9e7-4ba70001e873" />
<img width="547" height="407" alt="2025-12-20_16-26-17" src="https://github.com/user-attachments/assets/9af69864-effc-46aa-971c-9b0e147a2681" />
