### PR TITLE
fix: Support set-based relationships in list/detail views

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -113,7 +113,7 @@ class BaseAdmin:
         templates.env.globals["min"] = min
         templates.env.globals["zip"] = zip
         templates.env.globals["admin"] = self
-        templates.env.globals["is_list"] = lambda x: isinstance(x, list)
+        templates.env.globals["is_list"] = lambda x: isinstance(x, (list, set))
         templates.env.globals["get_object_identifier"] = get_object_identifier
 
         return templates

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -181,3 +181,23 @@ def test_validate_page_and_page_size():
 
     response = client.get("/admin/user/list?page=aaaa")
     assert response.status_code == 400
+
+
+def test_is_list_template_global():
+    """Test that is_list correctly identifies list and set types."""
+    app = Starlette()
+    admin = Admin(app=app, engine=engine)
+
+    is_list = admin.templates.env.globals["is_list"]
+
+    # Should return True for list and set
+    assert is_list([1, 2, 3]) is True
+    assert is_list({1, 2, 3}) is True
+    assert is_list([]) is True
+    assert is_list(set()) is True
+
+    # Should return False for non-collection types
+    assert is_list("string") is False
+    assert is_list(123) is False
+    assert is_list(None) is False
+    assert is_list({"key": "value"}) is False


### PR DESCRIPTION
## Problem

When SQLAlchemy relationships are defined with set type annotations:

```python
children: orm.Mapped[set['Child']] = orm.relationship(back_populates='parent')
```

SQLAlchemy uses `InstrumentedSet` instead of `InstrumentedList`. The `is_list` template helper only checked for `list` type, causing a `ValueError` when rendering related objects in list/detail views:

```
ValueError: Could not get primary keys for model InstrumentedSet({Child...})
```

## Solution

Extended `is_list` to check for both `list` and `set` types:

```python
is_list=lambda x: isinstance(x, (list, set))
```

This correctly handles `InstrumentedSet` collections in templates.

## Testing

Added test case `test_is_list_template_global` to verify the fix.