### PR TITLE
[Bug] Improved error display in the `delete` modal window

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -24,7 +24,12 @@ from starlette.datastructures import URL, FormData, MultiDict, UploadFile
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.responses import (
+    JSONResponse,
+    PlainTextResponse,
+    RedirectResponse,
+    Response,
+)
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
@@ -515,7 +520,7 @@ class Admin(BaseAdminView):
         referer_params = MultiDict(parse_qsl(referer_url.query))
         url = URL(str(request.url_for("admin:list", identity=identity)))
         url = url.include_query_params(**referer_params)
-        return Response(content=str(url))
+        return PlainTextResponse(content=str(url))
 
     @login_required
     async def create(self, request: Request) -> Response:

--- a/sqladmin/statics/js/main.js
+++ b/sqladmin/statics/js/main.js
@@ -4,7 +4,7 @@ $(document).on('shown.bs.modal', '#modal-delete', function (event) {
 
   var name = element.data("name");
   var pk = element.data("pk");
-  $("#modal-delete-text").text("This will permanently delete " + name + " " + pk + " ?");
+  $("#modal-delete-text").text("This will permanently delete " + name + " " + pk + "?");
 
   $("#modal-delete-button").attr("data-url", element.data("url"));
 });
@@ -13,11 +13,22 @@ $(document).on('click', '#modal-delete-button', function () {
   $.ajax({
     url: $(this).attr('data-url'),
     method: 'DELETE',
+    headers: {
+      'Accept': 'text/html',
+    },
     success: function (result) {
       window.location.href = result;
     },
-    error: function (request, status, error) {
-      alert(request.responseText);
+    error: function (request) {
+      const contentType = request.getResponseHeader('Content-Type') || '';
+
+      if (contentType.includes('text/html')) {
+        document.open();
+        document.write(request.responseText);
+        document.close();
+      } else {
+        alert(request.responseText);
+      }
     }
   });
 });

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -136,9 +136,11 @@
                       {% endif %}
                       {% if model_view.can_delete %}
                       <a href="#" data-name="{{ model_view.name }}" data-pk="{{ get_object_identifier(row) }}"
-                        data-url="{{ model_view._url_for_delete(request, row) }}" data-bs-toggle="modal"
-                        data-bs-target="#modal-delete" title="Delete">
-                        <span class="me-1"><i class="fa-solid fa-trash"></i></span>
+                         data-url="{{ model_view._url_for_delete(request, row) }}" data-bs-toggle="modal"
+                         data-bs-target="#modal-delete">
+                        <span data-bs-toggle="tooltip" data-bs-placement="top" title="Delete">
+                          <span class="me-1"><i class="fa-solid fa-trash"></i></span>
+                        </span>
                       </a>
                       {% endif %}
                     </td>


### PR DESCRIPTION
# Improved error display in the `delete` modal window

## 1. Alert when an `HTTPException` error occurs during the uninstall process, a browser alert with HTML is displayed instead of displaying the error page.

### Before:
<img width="660" height="1029" alt="Screenshot from 2026-01-15 00-48-42" src="https://github.com/user-attachments/assets/88598b14-ae4b-4dcf-912f-e97173814572" />

### After:
<img width="587" height="316" alt="Screenshot from 2026-01-15 00-45-15" src="https://github.com/user-attachments/assets/3c563df0-0c59-49f1-9024-14014b287a0e" />

## 2. Alert for 500 error and `admin.debug=True` during the uninstall process, HTML is displayed inside a browser alert instead of a debug page.

### Before:
<img width="660" height="1029" alt="Screenshot from 2026-01-15 00-48-10" src="https://github.com/user-attachments/assets/6908124d-789f-449c-8b86-30cfbd439f05" />

### After:
<img width="1918" height="1021" alt="Screenshot from 2026-01-15 00-50-43" src="https://github.com/user-attachments/assets/b02a4026-b3ec-4cae-ab21-f71d6f16f396" />

### When `admin.debug=False` 500 errors remain unchanged:
<img width="587" height="316" alt="Screenshot from 2026-01-15 00-44-51" src="https://github.com/user-attachments/assets/3b6822b5-6b33-463f-a608-4a2659235d17" />

## 3. Fixed the tooltip for the `delete` button.
### Before:
<img width="259" height="226" alt="Screenshot from 2026-01-15 00-49-02" src="https://github.com/user-attachments/assets/1ab43b42-d312-469b-82db-5f0254e51ed9" />

### After:
<img width="480" height="300" alt="Screenshot from 2026-01-15 00-34-31" src="https://github.com/user-attachments/assets/c9fd9aeb-194e-47d3-bb1e-0eeccf517235" />

### This is what the other button looks like now as an example:
<img width="259" height="226" alt="Screenshot from 2026-01-15 00-49-08" src="https://github.com/user-attachments/assets/2070aec1-2705-4146-99b1-5c37f448e294" />



