### PR TITLE
Add ModelView.search_auto_submit option for list search

### DIFF
--- a/docs/api_reference/model_view.md
+++ b/docs/api_reference/model_view.md
@@ -28,6 +28,7 @@
         - is_visible
         - is_accessible
         - column_searchable_list
+        - search_auto_submit
         - search_placeholder
         - column_sortable_list
         - column_default_sort

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -114,6 +114,7 @@ The options available are:
 - `column_exclude_list`: List of columns or column names to be excluded in the list page.
 - `column_formatters`: Dictionary of column formatters in the list page.
 - `column_searchable_list`: List of columns or column names to be searchable in the list page.
+- `search_auto_submit`: Enable or disable automatic search submit while typing in the list page search input. Default is `True`.
 - `column_sortable_list`: List of columns or column names to be sortable in the list page.
 - `column_default_sort`: Default sorting if no sorting is applied, tuple of (column, is_descending)
   or list of the tuple for multiple columns.
@@ -129,6 +130,7 @@ The options available are:
     class UserAdmin(ModelView, model=User):
         column_list = [User.id, User.name, "address.zip_code"]
         column_searchable_list = [User.name]
+        search_auto_submit = False
         column_sortable_list = [User.id]
         column_formatters = {User.name: lambda m, a: m.name[:10]}
         column_default_sort = [(User.email, True), (User.name, False)]

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -325,6 +325,13 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         ```
     """
 
+    search_auto_submit: ClassVar[bool] = True
+    """Automatically submit search while typing in list view.
+
+    When set to `True`, typing in the search input triggers a delayed search.
+    Set to `False` to require pressing `Enter` or clicking the search button.
+    """
+
     column_filters: ClassVar[Sequence[ColumnFilter]] = []
     """Collection of the filterable columns for the list view.
     Columns can either be string names or SQLAlchemy columns.

--- a/sqladmin/statics/js/main.js
+++ b/sqladmin/statics/js/main.js
@@ -67,6 +67,9 @@ var timeout = null;
 // Search
 $(document).on('keyup', '#search-input', function (e) {
   clearTimeout(timeout);
+  if ($(this).data('searchAutoSubmit') === false) {
+    return;
+  }
   // Make a new timeout set to go off in 1000ms (1 second)
   timeout = setTimeout(function () {
     $('#search-button').click();

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -77,6 +77,7 @@
                 <div class="col-md-4 text-muted">
                   <div class="input-group">
                     <input id="search-input" type="text" class="form-control"
+                      data-search-auto-submit="{{ 'true' if model_view.search_auto_submit else 'false' }}"
                       placeholder="Search: {{ model_view.search_placeholder() }}"
                       value="{{ request.query_params.get('search', '') }}">
                     <button id="search-button" class="btn" type="button">Search</button>

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -173,6 +173,8 @@ class UserAdmin(ModelView, model=User):
 
 class AddressAdmin(ModelView, model=Address):
     column_list = ["id", "user_id", "user", "user.profile.id"]
+    column_searchable_list = [Address.id]
+    search_auto_submit = False
     name_plural = "Addresses"
     export_max_rows = 3
 
@@ -752,7 +754,11 @@ async def test_searchable_list(client: AsyncClient) -> None:
 
     response = await client.get("/admin/user/list")
     assert "Search: name" in response.text
+    assert 'data-search-auto-submit="true"' in response.text
     assert "/admin/user/details/1" in response.text
+
+    response = await client.get("/admin/address/list")
+    assert 'data-search-auto-submit="false"' in response.text
 
     response = await client.get("/admin/user/list?search=ro")
     assert "/admin/user/details/1" in response.text

--- a/tests/test_views/test_view_sync.py
+++ b/tests/test_views/test_view_sync.py
@@ -165,6 +165,8 @@ class UserAdmin(ModelView, model=User):
 
 class AddressAdmin(ModelView, model=Address):
     column_list = ["id", "user_id", "user", "user.profile.id"]
+    column_searchable_list = [Address.id]
+    search_auto_submit = False
     name_plural = "Addresses"
     export_max_rows = 3
 
@@ -726,7 +728,11 @@ def test_searchable_list(client: TestClient) -> None:
 
     response = client.get("/admin/user/list")
     assert "Search: name" in response.text
+    assert 'data-search-auto-submit="true"' in response.text
     assert "/admin/user/details/1" in response.text
+
+    response = client.get("/admin/address/list")
+    assert 'data-search-auto-submit="false"' in response.text
 
     response = client.get("/admin/user/list?search=ro")
     assert "/admin/user/details/1" in response.text


### PR DESCRIPTION
## Summary

This PR adds a new `ModelView` option: `search_auto_submit` (default: `True`).

When set to `False`, the list search input no longer auto-submits while typing.
Users can still trigger search by pressing `Enter` or clicking the Search button.

## Changes

- Added `ModelView.search_auto_submit` with documentation string
- Passed the setting to the list template via `data-search-auto-submit`
- Updated list search JavaScript to respect the flag
- Added sync/async tests for rendered `data-search-auto-submit` values
- Updated docs and API reference for the new option

## Backward Compatibility

No breaking changes.

Default behavior remains unchanged because `search_auto_submit = True` by default.

## Tests

- `tests/test_views/test_view_sync.py::test_searchable_list`
- `tests/test_views/test_view_async.py::test_searchable_list`

Both tests pass locally.