### PR TITLE
Quality of Life updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ htmlcov/
 .mypy_cache/
 coverage.xml
 examples/
-.vscode/
+.vscode/*
+!.vscode/extensions.json
 .uploads
 test.db
 coverage.xml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "usernamehw.errorlens",
+        "eamodio.gitlens",
+        "yzhang.markdown-all-in-one",
+        "davidanson.vscode-markdownlint",
+        "shardulm94.trailing-spaces",
+        "charliermarsh.ruff",
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ actions = \
 	publish
 
 # ARGS used for `test`. `PY_ARGS` used for `lint` and `format`
-PY_ARGS := $(or $(filter %.py,$(ARGS)),sqladmin)
+PY_ARGS := $(or $(filter %.py,$(ARGS)),sqladmin tests)
 
 setup:
 	uv sync --all-groups

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "starlette",
+  "starlette==0.49.3,<0.50.0; python_version == '3.9'",
+  "starlette>=0.50,<2.0.0; python_version >= '3.10'",
   "wtforms >=3.1, <3.2",
   "jinja2",
   "python-multipart",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ requires-python = ">=3.9"
 license = "BSD-3-Clause"
 keywords = ["sqlalchemy", "fastapi", "starlette", "admin"]
 authors = [{ name = "Amin Alaee", email = "mohammadamin.alaee@gmail.com" }]
+maintainers = [
+  { name = "Miradil Zeynalli", email = "miradil.zeynalli@gmail.com" },
+]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",

--- a/sqladmin/_types.py
+++ b/sqladmin/_types.py
@@ -9,14 +9,20 @@ from typing import (
 )
 
 from sqlalchemy.engine import Engine
-from sqlalchemy.ext.asyncio import AsyncEngine
-from sqlalchemy.orm import ColumnProperty, InstrumentedAttribute, RelationshipProperty
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+from sqlalchemy.orm import (
+    ColumnProperty,
+    InstrumentedAttribute,
+    RelationshipProperty,
+    sessionmaker,
+)
 from sqlalchemy.sql.expression import Select
 from starlette.requests import Request
 
 MODEL_PROPERTY = Union[ColumnProperty, RelationshipProperty]
 ENGINE_TYPE = Union[Engine, AsyncEngine]
 MODEL_ATTR = Union[str, InstrumentedAttribute]
+SESSION_MAKER = Union[sessionmaker, async_sessionmaker]
 
 
 @runtime_checkable

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -5,7 +5,6 @@ import io
 import logging
 from types import MethodType
 from typing import (
-    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -17,7 +16,7 @@ from urllib.parse import parse_qsl, urljoin
 
 from jinja2 import ChoiceLoader, FileSystemLoader, PackageLoader
 from sqlalchemy.engine import Engine
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import Session, sessionmaker
 from starlette.applications import Starlette
 from starlette.datastructures import URL, FormData, MultiDict, UploadFile
@@ -39,15 +38,13 @@ from sqladmin.ajax import QueryAjaxModelLoader
 from sqladmin.authentication import AuthenticationBackend, login_required
 from sqladmin.forms import WTFORMS_ATTRS, WTFORMS_ATTRS_REVERSED
 from sqladmin.helpers import (
+    _SessionMaker,
     get_object_identifier,
     is_async_session_maker,
     slugify_action_name,
 )
 from sqladmin.models import BaseView, ModelView
 from sqladmin.templating import Jinja2Templates
-
-if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import async_sessionmaker  # type: ignore[attr-defined]
 
 __all__ = [
     "Admin",
@@ -69,7 +66,7 @@ class BaseAdmin:
         self,
         app: Starlette,
         engine: ENGINE_TYPE | None = None,
-        session_maker: sessionmaker | None = None,
+        session_maker: _SessionMaker | None = None,
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str | None = None,
@@ -91,8 +88,8 @@ class BaseAdmin:
         elif isinstance(self.engine, Engine):
             self.session_maker = sessionmaker(bind=self.engine, class_=Session)
         else:
-            self.session_maker = sessionmaker(
-                bind=self.engine,  # type: ignore[arg-type]
+            self.session_maker = async_sessionmaker(
+                bind=self.engine,
                 class_=AsyncSession,
             )
 
@@ -358,7 +355,7 @@ class Admin(BaseAdminView):
         self,
         app: Starlette,
         engine: ENGINE_TYPE | None = None,
-        session_maker: sessionmaker | "async_sessionmaker" | None = None,
+        session_maker: _SessionMaker | None = None,
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str | None = None,

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -33,12 +33,11 @@ from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
 from sqladmin._menu import CategoryMenu, Menu, ViewMenu
-from sqladmin._types import ENGINE_TYPE
+from sqladmin._types import ENGINE_TYPE, SESSION_MAKER
 from sqladmin.ajax import QueryAjaxModelLoader
 from sqladmin.authentication import AuthenticationBackend, login_required
 from sqladmin.forms import WTFORMS_ATTRS, WTFORMS_ATTRS_REVERSED
 from sqladmin.helpers import (
-    _SessionMaker,
     get_object_identifier,
     is_async_session_maker,
     slugify_action_name,
@@ -66,7 +65,7 @@ class BaseAdmin:
         self,
         app: Starlette,
         engine: ENGINE_TYPE | None = None,
-        session_maker: _SessionMaker | None = None,
+        session_maker: SESSION_MAKER | None = None,
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str | None = None,
@@ -355,7 +354,7 @@ class Admin(BaseAdminView):
         self,
         app: Starlette,
         engine: ENGINE_TYPE | None = None,
-        session_maker: _SessionMaker | None = None,
+        session_maker: SESSION_MAKER | None = None,
         base_url: str = "/admin",
         title: str = "Admin",
         logo_url: str | None = None,

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -21,11 +21,7 @@ from typing import (
 import anyio
 from sqlalchemy import Boolean, select
 from sqlalchemy import inspect as sqlalchemy_inspect
-from sqlalchemy.orm import (
-    ColumnProperty,
-    RelationshipProperty,
-    sessionmaker,
-)
+from sqlalchemy.orm import ColumnProperty, RelationshipProperty
 from sqlalchemy.sql.elements import Label
 from wtforms import (
     DecimalField,
@@ -63,6 +59,7 @@ from sqladmin.fields import (
     SelectField,
 )
 from sqladmin.helpers import (
+    _SessionMaker,
     choice_type_coerce_factory,
     get_direction,
     get_object_identifier,
@@ -128,7 +125,7 @@ class ModelConverterBase:
     async def _prepare_kwargs(
         self,
         prop: MODEL_PROPERTY,
-        session_maker: sessionmaker,
+        session_maker: _SessionMaker,
         field_args: dict[str, Any],
         field_widget_args: dict[str, Any],
         form_include_pk: bool,
@@ -210,7 +207,7 @@ class ModelConverterBase:
         self,
         prop: RelationshipProperty,
         kwargs: dict,
-        session_maker: sessionmaker,
+        session_maker: _SessionMaker,
         loader: QueryAjaxModelLoader | None = None,
     ) -> dict:
         nullable = True
@@ -230,7 +227,7 @@ class ModelConverterBase:
     async def _prepare_select_options(
         self,
         prop: RelationshipProperty,
-        session_maker: sessionmaker,
+        session_maker: _SessionMaker,
     ) -> list[tuple[str, Any]]:
         target_model = prop.mapper.class_
         stmt = select(target_model)
@@ -288,7 +285,7 @@ class ModelConverterBase:
         self,
         model: type,
         prop: MODEL_PROPERTY,
-        session_maker: sessionmaker,
+        session_maker: _SessionMaker,
         field_args: dict[str, Any],
         field_widget_args: dict[str, Any],
         form_include_pk: bool,
@@ -682,7 +679,7 @@ class ModelConverter(ModelConverterBase):
 
 async def get_model_form(
     model: type,
-    session_maker: sessionmaker,
+    session_maker: _SessionMaker,
     only: Sequence[str] | None = None,
     exclude: Sequence[str] | None = None,
     column_labels: dict[str, str] | None = None,

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -35,7 +35,7 @@ from wtforms import (
 )
 from wtforms.fields.core import UnboundField
 
-from sqladmin._types import MODEL_PROPERTY
+from sqladmin._types import MODEL_PROPERTY, SESSION_MAKER
 from sqladmin._validators import (
     ColorValidator,
     CurrencyValidator,
@@ -59,7 +59,6 @@ from sqladmin.fields import (
     SelectField,
 )
 from sqladmin.helpers import (
-    _SessionMaker,
     choice_type_coerce_factory,
     get_direction,
     get_object_identifier,
@@ -125,7 +124,7 @@ class ModelConverterBase:
     async def _prepare_kwargs(
         self,
         prop: MODEL_PROPERTY,
-        session_maker: _SessionMaker,
+        session_maker: SESSION_MAKER,
         field_args: dict[str, Any],
         field_widget_args: dict[str, Any],
         form_include_pk: bool,
@@ -207,7 +206,7 @@ class ModelConverterBase:
         self,
         prop: RelationshipProperty,
         kwargs: dict,
-        session_maker: _SessionMaker,
+        session_maker: SESSION_MAKER,
         loader: QueryAjaxModelLoader | None = None,
     ) -> dict:
         nullable = True
@@ -227,7 +226,7 @@ class ModelConverterBase:
     async def _prepare_select_options(
         self,
         prop: RelationshipProperty,
-        session_maker: _SessionMaker,
+        session_maker: SESSION_MAKER,
     ) -> list[tuple[str, Any]]:
         target_model = prop.mapper.class_
         stmt = select(target_model)
@@ -285,7 +284,7 @@ class ModelConverterBase:
         self,
         model: type,
         prop: MODEL_PROPERTY,
-        session_maker: _SessionMaker,
+        session_maker: SESSION_MAKER,
         field_args: dict[str, Any],
         field_widget_args: dict[str, Any],
         form_include_pk: bool,
@@ -679,7 +678,7 @@ class ModelConverter(ModelConverterBase):
 
 async def get_model_form(
     model: type,
-    session_maker: _SessionMaker,
+    session_maker: SESSION_MAKER,
     only: Sequence[str] | None = None,
     exclude: Sequence[str] | None = None,
     column_labels: dict[str, str] | None = None,

--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -16,14 +16,14 @@ from typing import (
 )
 
 from sqlalchemy import Column, inspect
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import RelationshipProperty, sessionmaker
 
 from sqladmin._types import MODEL_PROPERTY
 
 T = TypeVar("T")
 
-
+_SessionMaker = sessionmaker | async_sessionmaker
 _filename_ascii_strip_re = re.compile(r"[^A-Za-z0-9_.-]")
 _windows_device_files = (
     "CON",
@@ -320,5 +320,5 @@ def choice_type_coerce_factory(type_: Any) -> Callable[[Any], Any]:
     return choice_coerce
 
 
-def is_async_session_maker(session_maker: sessionmaker) -> bool:
+def is_async_session_maker(session_maker: _SessionMaker) -> bool:
     return AsyncSession in session_maker.class_.__mro__

--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -13,18 +13,16 @@ from typing import (
     Callable,
     Generator,
     TypeVar,
-    Union,
 )
 
 from sqlalchemy import Column, inspect
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from sqlalchemy.orm import RelationshipProperty, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import RelationshipProperty
 
-from sqladmin._types import MODEL_PROPERTY
+from sqladmin._types import MODEL_PROPERTY, SESSION_MAKER
 
 T = TypeVar("T")
 
-_SessionMaker = Union[sessionmaker, async_sessionmaker]
 _filename_ascii_strip_re = re.compile(r"[^A-Za-z0-9_.-]")
 _windows_device_files = (
     "CON",
@@ -321,5 +319,5 @@ def choice_type_coerce_factory(type_: Any) -> Callable[[Any], Any]:
     return choice_coerce
 
 
-def is_async_session_maker(session_maker: _SessionMaker) -> bool:
+def is_async_session_maker(session_maker: SESSION_MAKER) -> bool:
     return AsyncSession in session_maker.class_.__mro__

--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     Generator,
     TypeVar,
+    Union,
 )
 
 from sqlalchemy import Column, inspect
@@ -23,7 +24,7 @@ from sqladmin._types import MODEL_PROPERTY
 
 T = TypeVar("T")
 
-_SessionMaker = sessionmaker | async_sessionmaker
+_SessionMaker = Union[sessionmaker, async_sessionmaker]
 _filename_ascii_strip_re = re.compile(r"[^A-Za-z0-9_.-]")
 _windows_device_files = (
     "CON",

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -39,6 +39,7 @@ from wtforms.fields.core import UnboundField
 from sqladmin._queries import Query
 from sqladmin._types import (
     MODEL_ATTR,
+    SESSION_MAKER,
     ColumnFilter,
     OperationColumnFilter,
     SimpleColumnFilter,
@@ -49,7 +50,6 @@ from sqladmin.formatters import BASE_FORMATTERS
 from sqladmin.forms import ModelConverter, ModelConverterBase, get_model_form
 from sqladmin.helpers import (
     Writer,
-    _SessionMaker,
     get_object_identifier,
     get_primary_keys,
     object_identifier_values,
@@ -209,7 +209,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
 
     # Internals
     pk_columns: ClassVar[Tuple[Column]]
-    session_maker: ClassVar[_SessionMaker]
+    session_maker: ClassVar[SESSION_MAKER]
     is_async: ClassVar[bool] = False
     is_model: ClassVar[bool] = True
     ajax_lookup_url: ClassVar[str] = ""

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -25,7 +25,7 @@ from urllib.parse import urlencode
 import anyio
 from sqlalchemy import Column, String, asc, cast, desc, func, inspect, or_
 from sqlalchemy.exc import NoInspectionAvailable
-from sqlalchemy.orm import selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.exc import DetachedInstanceError
 from sqlalchemy.sql.elements import ClauseElement
 from sqlalchemy.sql.expression import Select, select
@@ -49,6 +49,7 @@ from sqladmin.formatters import BASE_FORMATTERS
 from sqladmin.forms import ModelConverter, ModelConverterBase, get_model_form
 from sqladmin.helpers import (
     Writer,
+    _SessionMaker,
     get_object_identifier,
     get_primary_keys,
     object_identifier_values,
@@ -64,8 +65,6 @@ from sqladmin.pretty_export import PrettyExport
 from sqladmin.templating import Jinja2Templates
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import async_sessionmaker  # type: ignore[attr-defined]
-
     from sqladmin.application import BaseAdmin
 
 __all__ = [
@@ -210,12 +209,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
 
     # Internals
     pk_columns: ClassVar[Tuple[Column]]
-    session_maker: ClassVar[  # type: ignore[no-any-unimported]
-        Union[
-            sessionmaker,
-            "async_sessionmaker",
-        ]
-    ]
+    session_maker: ClassVar[_SessionMaker]
     is_async: ClassVar[bool] = False
     is_model: ClassVar[bool] = True
     ajax_lookup_url: ClassVar[str] = ""

--- a/sqladmin/widgets.py
+++ b/sqladmin/widgets.py
@@ -120,7 +120,5 @@ class BooleanInputWidget(widgets.Input):
             kwargs["checked"] = True
 
         return Markup(
-            '<div class="form-switch d-flex align-items-center h-100">'
-            + str(Markup.escape(super().__call__(field, **kwargs)))
-            + "</div>"
-        )
+            '<div class="form-switch d-flex align-items-center h-100">%s</div>'
+        ) % Markup.escape(super().__call__(field, **kwargs))

--- a/tests/test_ajax.py
+++ b/tests/test_ajax.py
@@ -3,8 +3,8 @@ from typing import Any, AsyncGenerator
 import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, Integer, String, select
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import declarative_base, relationship, selectinload, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import declarative_base, relationship, selectinload
 from starlette.applications import Starlette
 
 from sqladmin import Admin, ModelView
@@ -13,8 +13,10 @@ from tests.common import async_engine as engine
 
 pytestmark = pytest.mark.anyio
 
-Base = declarative_base()  # type: Any
-session_maker = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+Base = declarative_base()
+session_maker = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
 
 app = Starlette()
 admin = Admin(app=app, engine=engine)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -8,6 +8,7 @@ from starlette.datastructures import MutableHeaders
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.routing import Route
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -97,20 +98,23 @@ def test_middlewares() -> None:
 
 
 def test_get_save_redirect_url():
-    app = Starlette()
+    async def index(request: Request):
+        obj = User(id=1)
+        form_data = await request.form()
+        url = admin.get_save_redirect_url(request, form_data, admin.views[0], obj)
+        return Response(str(url))
+
+    app = Starlette(
+        routes=[
+            Route("/{identity}", index, methods=["POST"]),
+        ]
+    )
     admin = Admin(app=app, engine=engine)
 
     class UserAdmin(ModelView, model=User):
         save_as = True
 
     admin.add_view(UserAdmin)
-
-    @app.route("/{identity}", methods=["POST"])
-    async def index(request: Request):
-        obj = User(id=1)
-        form_data = await request.form()
-        url = admin.get_save_redirect_url(request, form_data, admin.views[0], obj)
-        return Response(str(url))
 
     client = TestClient(app)
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -2,8 +2,8 @@ from typing import Generator
 
 import pytest
 from sqlalchemy import Column, Integer
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import declarative_base
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse
@@ -14,8 +14,10 @@ from sqladmin.authentication import AuthenticationBackend
 from sqladmin.models import ModelView
 from tests.common import sync_engine as engine
 
-Base = declarative_base()  # type: Any
-session_maker = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+Base = declarative_base()
+session_maker = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
 
 
 class Movie(Base):
@@ -86,14 +88,14 @@ def test_login_failure(client: TestClient) -> None:
 def test_login(client: TestClient) -> None:
     response = client.post("/admin/login", data={"username": "a", "password": "b"})
 
-    assert len(response.cookies) == 1
+    assert len(client.cookies) == 1
     assert response.status_code == 200
 
 
 def test_logout(client: TestClient) -> None:
     response = client.get("/admin/logout")
 
-    assert len(response.cookies) == 0
+    assert len(client.cookies) == 0
     assert response.status_code == 200
     assert response.url == "http://testserver/admin/login"
 
@@ -103,7 +105,6 @@ def test_expose_access_login_required_views(client: TestClient) -> None:
     assert response.url == "http://testserver/admin/login"
 
     response = client.post("/admin/login", data={"username": "a", "password": "b"})
-    client.cookies = response.cookies
 
     response = client.get("/admin/custom")
     assert {"status": "ok"} == response.json()
@@ -114,7 +115,6 @@ def test_action_access_login_required_views(client: TestClient) -> None:
     assert response.url == "http://testserver/admin/login"
 
     response = client.post("/admin/login", data={"username": "a", "password": "b"})
-    client.cookies = response.cookies
 
     response = client.get("/admin/movie/action/test")
     assert {"status": "ok"} == response.json()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -14,8 +14,8 @@ from sqlalchemy import (
     Integer,
     String,
 )
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import declarative_base
 from starlette.applications import Starlette
 
 from sqladmin import Admin, ModelView
@@ -38,7 +38,9 @@ except ImportError:
     Uuid = None
 
 Base = declarative_base()  # type: Any
-session_maker = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+session_maker = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
 
 app = Starlette()
 admin = Admin(app=app, engine=engine)
@@ -162,7 +164,9 @@ async def prepare_data(prepare_database: Any) -> AsyncGenerator[None, None]:
             salary=80000.50,
             description="Senior administrator with management responsibilities",
             birthdate=datetime.date(2001, 7, 14),
-            created_at=datetime.datetime(2024, 11, 12, 3, 4, 5, tzinfo=datetime.timezone.utc),
+            created_at=datetime.datetime(
+                2024, 11, 12, 3, 4, 5, tzinfo=datetime.timezone.utc
+            ),
         )
         user2 = User(
             name="Regular User",
@@ -173,7 +177,9 @@ async def prepare_data(prepare_database: Any) -> AsyncGenerator[None, None]:
             salary=55000.75,
             description="Software developer specializing in web applications",
             birthdate=datetime.date(1994, 5, 31),
-            created_at=datetime.datetime(2024, 12, 31, 23, 59, 58, tzinfo=datetime.timezone.utc),
+            created_at=datetime.datetime(
+                2024, 12, 31, 23, 59, 58, tzinfo=datetime.timezone.utc
+            ),
         )
         user3 = User(
             name="Test User",
@@ -184,7 +190,9 @@ async def prepare_data(prepare_database: Any) -> AsyncGenerator[None, None]:
             salary=65000.00,
             description="Data analyst working on business intelligence",
             birthdate=datetime.date(1998, 10, 31),
-            created_at=datetime.datetime(2023, 3, 14, 12, 30, 0, tzinfo=datetime.timezone.utc),
+            created_at=datetime.datetime(
+                2023, 3, 14, 12, 30, 0, tzinfo=datetime.timezone.utc
+            ),
         )
         session.add_all([user1, user2, user3])
         await session.commit()
@@ -918,7 +926,9 @@ async def test_column_filter_conversion_edge_cases():
     result = created_at_filter._convert_value_for_column(
         "2021-11-30T22:33:43+00:00", User.created_at.property.columns[0]
     )
-    assert result == datetime.datetime(2021, 11, 30, 22, 33, 43, tzinfo=datetime.timezone.utc)
+    assert result == datetime.datetime(
+        2021, 11, 30, 22, 33, 43, tzinfo=datetime.timezone.utc
+    )
 
     # Test valid date conversion
     birthdate_filter = OperationColumnFilter(User.birthdate)

--- a/tests/test_forms/test_forms.py
+++ b/tests/test_forms/test_forms.py
@@ -20,14 +20,13 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, INET, MACADDR, UUID
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import (
     ColumnProperty,
     column_property,
     composite,
     declarative_base,
     relationship,
-    sessionmaker,
 )
 from wtforms import BooleanField, Field, Form, IntegerField, StringField, TimeField
 from wtforms.fields.core import UnboundField
@@ -39,8 +38,8 @@ from tests.common import async_engine as engine
 
 pytestmark = pytest.mark.anyio
 
-Base = declarative_base()  # type: ignore
-session_maker = sessionmaker(bind=engine, class_=AsyncSession)
+Base = declarative_base()
+session_maker = async_sessionmaker(bind=engine, class_=AsyncSession)
 
 
 class Status(enum.Enum):

--- a/tests/test_forms/test_multi_pk_forms.py
+++ b/tests/test_forms/test_multi_pk_forms.py
@@ -2,16 +2,16 @@ from typing import AsyncGenerator
 
 import pytest
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import declarative_base, relationship
 
 from sqladmin.forms import get_model_form
 from tests.common import async_engine as engine
 
 pytestmark = pytest.mark.anyio
 
-Base = declarative_base()  # type: ignore
-session_maker = sessionmaker(bind=engine, class_=AsyncSession)
+Base = declarative_base()
+session_maker = async_sessionmaker(bind=engine, class_=AsyncSession)
 
 
 class Service(Base):

--- a/tests/test_integrations/test_sqlalchemy_utils.py
+++ b/tests/test_integrations/test_sqlalchemy_utils.py
@@ -2,8 +2,8 @@ import enum
 
 import pytest
 from sqlalchemy import Column, Integer
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import declarative_base
 from sqlalchemy_utils import (
     ArrowType,
     ChoiceType,
@@ -23,8 +23,8 @@ from tests.common import async_engine as engine
 
 pytestmark = pytest.mark.anyio
 
-Base = declarative_base()  # type: ignore
-session_maker = sessionmaker(bind=engine, class_=AsyncSession)
+Base = declarative_base()
+session_maker = async_sessionmaker(bind=engine, class_=AsyncSession)
 
 
 class RoleEnum(enum.Enum):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ from tests.common import sync_engine as engine
 
 pytestmark = pytest.mark.anyio
 
-Base = declarative_base()  # type: ignore
+Base = declarative_base()
 session_maker = sessionmaker(bind=engine)
 
 app = Starlette()
@@ -569,8 +569,7 @@ def test_sort_query() -> None:
 
 
 def test_count_query() -> None:
-    class AddressAdmin(ModelView, model=Address):
-        ...
+    class AddressAdmin(ModelView, model=Address): ...
 
     request = Request({"type": "http"})
     stmt = AddressAdmin().count_query(request)

--- a/tests/test_pretty_export.py
+++ b/tests/test_pretty_export.py
@@ -13,7 +13,7 @@ from tests.common import sync_engine as engine
 
 pytestmark = pytest.mark.anyio
 
-Base = declarative_base()  # type: ignore
+Base = declarative_base()
 session_maker = sessionmaker(bind=engine)
 
 

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -16,8 +16,8 @@ from sqlalchemy import (
     func,
     select,
 )
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import declarative_base, relationship, selectinload, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import declarative_base, relationship, selectinload
 from starlette.applications import Starlette
 from starlette.requests import Request
 
@@ -26,8 +26,10 @@ from tests.common import async_engine as engine
 
 pytestmark = pytest.mark.anyio
 
-Base = declarative_base()  # type: Any
-session_maker = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+Base = declarative_base()
+session_maker = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
 
 app = Starlette()
 admin = Admin(app=app, engine=engine)

--- a/uv.lock
+++ b/uv.lock
@@ -2375,7 +2375,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "sqlalchemy" },
     { name = "starlette", version = "0.49.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "starlette", version = "0.50.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "wtforms" },
 ]
 
@@ -2431,7 +2431,8 @@ requires-dist = [
     { name = "jinja2" },
     { name = "python-multipart" },
     { name = "sqlalchemy", specifier = ">=2.0" },
-    { name = "starlette" },
+    { name = "starlette", marker = "python_full_version == '3.9.*'", specifier = "==0.49.3,<0.50.0" },
+    { name = "starlette", marker = "python_full_version >= '3.10'", specifier = ">=0.50,<2.0.0" },
     { name = "wtforms", specifier = ">=3.1,<3.2" },
 ]
 provides-extras = ["full"]
@@ -2571,7 +2572,7 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -2580,9 +2581,9 @@ dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
1. Added extensions.json file for recommended extensions in VSCode
2. Added support for starlette 1.0. Now python3.9 uses 0.49.3, python 3.10 and higher uses >=0.50,<2.0.0
3. Replaced some `sessionmaker`s with `async_sessionmaker`
4. Now linting and formatting test files as well