### PR TITLE
Docs: add contributing page to documentation site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,16 +49,19 @@ If you are proposing a feature:
 Ready to contribute? Here's how to set up `sqladmin` for local development.
 
 1. Fork the `sqladmin` repo on GitHub.
-2. Clone your fork locally
+2. Clone your fork locally and add the upstream remote:
 
     ```
     $ git clone git@github.com:your_name_here/sqladmin.git
+    $ cd sqladmin
+    $ git remote add upstream git@github.com:smithyhq/sqladmin.git
     ```
 
-3. Install [`uv`](https://docs.astral.sh/uv/) for project management. Install dependencies
-   ```
-   $ make setup
-   ```
+3. Install [`uv`](https://docs.astral.sh/uv/) for project management. Install dependencies:
+
+    ```
+    $ make setup
+    ```
 
 4. Install [`pre-commit`](https://pre-commit.com/) and apply it:
 
@@ -67,10 +70,13 @@ Ready to contribute? Here's how to set up `sqladmin` for local development.
     $ pre-commit install
     ```
 
-5. Create a branch for local development:
+5. Always branch off `main`. Create a branch for local development following
+   the [branch naming conventions](#branch-naming-conventions) below:
 
     ```
-    $ git checkout -b name-of-your-bugfix-or-feature
+    $ git checkout main
+    $ git pull upstream main
+    $ git checkout -b fix/short-description-of-fix
     ```
 
     Now you can make your changes locally.
@@ -88,15 +94,80 @@ Ready to contribute? Here's how to set up `sqladmin` for local development.
     $ make test
     ```
 
-8. Commit your changes and push your branch to GitHub:
+    To run a specific test file or test case:
+
+    ```
+    $ uv run pytest tests/test_auth.py
+    $ uv run pytest tests/test_auth.py::test_ajax_lookup_requires_auth
+    ```
+
+    To run tests with coverage report:
+
+    ```
+    $ uv run pytest --cov=sqladmin --cov-report=term-missing
+    ```
+
+    Note: test coverage must not drop below 95%.
+
+8. Commit your changes following the [commit message conventions](#commit-message-conventions)
+   and push your branch to GitHub:
 
     ```
     $ git add .
-    $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
+    $ git commit -m "fix: short description of your change"
+    $ git push origin fix/short-description-of-fix
     ```
 
-9.  Submit a pull request through the GitHub website.
+9. Submit a pull request through the GitHub website.
+
+## Branch Naming Conventions
+
+Always create branches from the latest `main`. Use one of the following
+prefixes depending on the nature of your change:
+
+| Prefix | When to use | Example |
+|--------|-------------|---------|
+| `fix/` | Bug fixes | `fix/uuid-primary-key-error` |
+| `feat/` | New features | `feat/add-json-editor` |
+| `docs/` | Documentation only changes | `docs/add-contributing-page` |
+| `test/` | Adding or fixing tests only | `test/model-view-export-coverage` |
+| `refactor/` | Code refactoring without behavior change | `refactor/simplify-model-converter` |
+| `chore/` | Dependency bumps, CI, tooling | `chore/bump-starlette-to-0-50` |
+
+Keep branch names lowercase and use hyphens, not underscores.
+Each branch should address a single concern — do not mix a bug fix
+and a new feature in the same branch.
+
+## Commit Message Conventions
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/).
+The format is:
+
+```
+<type>: <short summary in present tense>
+```
+
+Common types:
+
+| Type | When to use |
+|------|-------------|
+| `fix` | A bug fix |
+| `feat` | A new feature |
+| `docs` | Documentation changes |
+| `test` | Adding or updating tests |
+| `refactor` | Refactoring without behavior change |
+| `chore` | Tooling, dependencies, CI |
+
+If your commit closes a GitHub issue, reference it in the commit body:
+
+```
+feat: add json editor for json column fields
+
+JSON column fields now render an interactive editor
+instead of a plain textarea input.
+
+Closes #1025
+```
 
 ## Pull Request Guidelines
 
@@ -109,3 +180,33 @@ Before you submit a pull request, check that it meets these guidelines:
 3. The pull request should work from Python 3.9 till 3.14. Check
    https://github.com/smithyhq/sqladmin/actions
    and make sure that the tests pass for all supported Python versions.
+4. One pull request should address one concern. If you have multiple
+   independent changes, open separate pull requests for each.
+5. Link the related issue in your pull request description using
+   `Closes #<issue-number>` or `Fixes #<issue-number>`.
+
+## Project Structure
+
+```
+sqladmin/
+├── sqladmin/              # source code
+│   ├── application.py     # Admin class, route handlers
+│   ├── models.py          # ModelView base class
+│   ├── authentication.py  # AuthenticationBackend, login_required
+│   ├── ajax.py            # AJAX lookup logic
+│   └── ...
+├── tests/                 # test suite
+├── docs/                  # MkDocs documentation source
+├── mkdocs.yml             # documentation site config
+└── pyproject.toml         # project metadata and dependencies
+```
+
+## Keeping Your Fork Up to Date
+
+Before starting any new work, sync your fork with upstream:
+
+```
+$ git checkout main
+$ git pull upstream main
+$ git push origin main
+```

--- a/docs/api_reference/application.md
+++ b/docs/api_reference/application.md
@@ -15,3 +15,22 @@
 
 ::: sqladmin.application.action
     handler: python
+
+::: sqladmin.flash.FlashLevel
+    handler: python
+
+::: sqladmin.flash.Flash
+    handler: python
+    options:
+      members:
+        - flash
+        - info
+        - success
+        - warning
+        - error
+
+::: sqladmin.flash.flash
+    handler: python
+
+::: sqladmin.flash.get_flashed_messages
+    handler: python

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -519,51 +519,67 @@ The available options for `action` are:
 - `add_in_detail`: A boolean indicating if this action should be available in detail page.
 - `confirmation_message`: A string message that if defined, will open a modal to ask for confirmation before calling the action method.
 
-You can use `Flash` utility class to notify results to the custom action. 
 
-#### Flash Utility Class
-All methods are class methods and require the request object to access the user session.
+### Toast Notifications
 
-1. **Primary Method**: `Flash.flash()`
+You can display toast notifications after a custom action completes using
+either the `Flash` utility class or the low-level `flash()` function.
 
-The general-purpose method for adding any message with an explicitly defined `FlashLevel`.
+#### Using the `Flash` class (recommended)
 
-| Parameter | Type         | Default           | Description                              |
-|-----------|--------------|-------------------|------------------------------------------|
-| `request` | `Request`    |                   | The current incoming request object.     |
-| `message` | `str`        |                   | The main text content of the message.    |
-| `level`   | `FlashLevel` | `FlashLevel.info` | The severity level.                      |
-| `title`   | `str`        | `""`              | An optional title for the flash message. |
+`Flash` provides convenience class methods that set the severity level automatically.
+Import it directly from `sqladmin`:
 
-!!! example
+```python
+from sqladmin import BaseView, action, Flash
+from starlette.responses import RedirectResponse
 
-    ```python
-    from sqladmin import Flash, FlashLevel
-    
-    # Explicitly setting the level
-    Flash.flash(request, "A crucial server process has started.", FlashLevel.warning, "System Alert")
-    ```
+class UserAdmin(ModelView, model=User):
+    @action(name="approve_users", label="Approve", add_in_list=True)
+    async def approve_users(self, request: Request):
+        pks = request.query_params.get("pks", "").split(",")
+        if pks:
+            for pk in pks:
+                model: User = await self.get_object_for_edit(pk)
+                ...
 
-2. **Convenience Methods (Shortcuts)**
+        Flash.success(request, "Users approved successfully")
+        referer = request.headers.get("Referer")
+        if referer:
+            return RedirectResponse(referer)
+        else:
+            return RedirectResponse(request.url_for("admin:list", identity=self.identity))
+```
 
-These methods simplify message creation by automatically setting the appropriate `FlashLevel`. 
-They accept the same `request`, `message`, and optional `title` parameters.
+The available convenience methods are:
 
-| Method                                      | Level Set            | Description                                      |
-|---------------------------------------------|----------------------|--------------------------------------------------|
-| `Flash.info(request, message, title="")`    | `FlashLevel.info`    | Adds a general information message.              |
-| `Flash.error(request, message, title="")`   | `FlashLevel.error`   | Adds a high-severity error message.              |
-| `Flash.warning(request, message, title="")` | `FlashLevel.warning` | Adds a cautionary message.                       |
-| `Flash.success(request, message, title="")` | `FlashLevel.success` | Adds a message confirming successful completion. |
+* `Flash.info(request, message, title="")` — informational message (blue)
+* `Flash.success(request, message, title="")` — success message (green)
+* `Flash.warning(request, message, title="")` — warning message (yellow)
+* `Flash.error(request, message, title="")` — error message (red)
 
-!!! example
+For custom levels use `Flash.flash()` with an explicit `FlashLevel`:
 
-    ```python
-    from sqladmin import Flash, FlashLevel
-    
-    # Using the success shortcut
-    Flash.success(request, "Your profile was updated successfully.", "Update Complete")
-    
-    # Using the error shortcut
-    Flash.error(request, "Access denied. Invalid credentials provided.")
-    ```
+```python
+from sqladmin import Flash, FlashLevel
+
+Flash.flash(request, "Server process started.", FlashLevel.warning, "System Alert")
+```
+
+#### Using the `flash()` function
+
+For cases where you want to pass a raw Bootstrap color class string directly,
+use the low-level `flash()` function from `sqladmin.flash`:
+
+```python
+from sqladmin.flash import flash
+
+flash(request, "Operation completed.", category="success", title="Done")
+flash(request, "Something went wrong.", category="danger")
+flash(request, "Process started.")  # defaults to "primary" (blue)
+```
+
+!!! note
+    Flash messages are stored in the session and displayed as Bootstrap toast
+    notifications on the next page render. They are automatically cleared after
+    being displayed. If no session is available, messages are silently ignored.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,6 @@
+# Contributing
+
+Contributing guidelines are maintained in the repository root.
+
+Please read [CONTRIBUTING.md](https://github.com/smithyhq/sqladmin/blob/main/CONTRIBUTING.md)
+for the full guide.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - ModelView: "api_reference/model_view.md"
       - BaseView: "api_reference/base_view.md"
       - Authentication: "api_reference/authentication.md"
+  - Contributing: "contributing.md"
 
 markdown_extensions:
   - markdown.extensions.codehilite:

--- a/sqladmin/flash.py
+++ b/sqladmin/flash.py
@@ -5,9 +5,16 @@ from starlette.requests import Request
 
 
 class FlashLevel(Enum):
-    """
-    Defines the standard severity levels for flash messages.
-    These values are typically used as CSS classes or categories.
+    """Defines the standard severity levels for flash messages.
+
+    These values map directly to Bootstrap contextual color classes
+    used in the toast notification UI.
+
+    Attributes:
+        info: General informational message. Maps to Bootstrap `primary` (blue).
+        error: High-severity error message. Maps to Bootstrap `danger` (red).
+        warning: Cautionary message. Maps to Bootstrap `warning` (yellow).
+        success: Successful operation message. Maps to Bootstrap `success` (green).
     """
 
     info = "primary"
@@ -17,9 +24,14 @@ class FlashLevel(Enum):
 
 
 class Flash:
-    """
-    A utility class providing convenient class methods for creating
-    session-based flash messages with predefined severity levels.
+    """Utility class providing class methods for session-based flash messages.
+
+    Flash messages are stored in the session and displayed as Bootstrap toast
+    notifications on the next page render. They are automatically cleared after
+    being displayed.
+
+    All methods are class methods and require the `request` object to access
+    the user session. If no session is available, messages are silently ignored.
     """
 
     @classmethod
@@ -30,14 +42,32 @@ class Flash:
         level: FlashLevel = FlashLevel.info,
         title: str = "",
     ) -> bool:
-        """
-        Adds a custom flash message in any custom level.
+        """Add a flash message with an explicitly defined severity level.
+
+        This is the primary method. Use the convenience methods (`info`,
+        `success`, `warning`, `error`) to avoid specifying the level manually.
 
         Args:
-            request: The incoming request object.
-            message: The message content.
-            level: The custom flash level.
-            title: An optional title.
+            request: The current incoming request object.
+            message: The main text content of the message.
+            level: The severity level. Defaults to `FlashLevel.info`.
+            title: An optional title shown in the toast header. Defaults to `""`.
+
+        Returns:
+            `True` if the message was stored successfully,
+            `False` if no session is available.
+
+        Example:
+            ```python
+            from sqladmin import Flash, FlashLevel
+
+            Flash.flash(
+                request,
+                "A crucial server process has started.",
+                FlashLevel.warning,
+                "System Alert",
+            )
+            ```
         """
         return flash(
             request,
@@ -48,74 +78,116 @@ class Flash:
 
     @classmethod
     def info(cls, request: Request, message: str, title: str = "") -> bool:
-        """
-        Adds an informational flash message (level: INFO).
+        """Add an informational flash message.
 
         Args:
-            request: The incoming request object.
+            request: The current incoming request object.
             message: The message content.
-            title: An optional title.
-        """
-        return cls.flash(
-            request,
-            message,
-            FlashLevel.info,
-            title,
-        )
+            title: An optional title shown in the toast header. Defaults to `""`.
 
-    @classmethod
-    def error(cls, request: Request, message: str, title: str = "") -> bool:
-        """
-        Adds an error flash message (level: ERROR).
+        Returns:
+            `True` if the message was stored successfully,
+            `False` if no session is available.
 
-        Args:
-            request: The incoming request object.
-            message: The message content.
-            title: An optional title.
-        """
-        return cls.flash(
-            request,
-            message,
-            FlashLevel.error,
-            title,
-        )
+        Example:
+            ```python
+            from sqladmin import Flash
 
-    @classmethod
-    def warning(cls, request: Request, message: str, title: str = "") -> bool:
+            Flash.info(request, "Your export is being processed in the background.")
+            ```
         """
-        Adds a warning flash message (level: WARNING).
-
-        Args:
-            request: The incoming request object.
-            message: The message content.
-            title: An optional title.
-        """
-        return cls.flash(
-            request,
-            message,
-            FlashLevel.warning,
-            title,
-        )
+        return cls.flash(request, message, FlashLevel.info, title)
 
     @classmethod
     def success(cls, request: Request, message: str, title: str = "") -> bool:
-        """
-        Adds a successful action flash message (level: SUCCESS).
+        """Add a success flash message.
 
         Args:
-            request: The incoming request object.
+            request: The current incoming request object.
             message: The message content.
-            title: An optional title.
+            title: An optional title shown in the toast header. Defaults to `""`.
+
+        Returns:
+            `True` if the message was stored successfully,
+            `False` if no session is available.
+
+        Example:
+            ```python
+            from sqladmin import Flash
+
+            Flash.success(request, "Users approved successfully.", "Done")
+            ```
         """
-        return cls.flash(
-            request,
-            message,
-            FlashLevel.success,
-            title,
-        )
+        return cls.flash(request, message, FlashLevel.success, title)
+
+    @classmethod
+    def warning(cls, request: Request, message: str, title: str = "") -> bool:
+        """Add a warning flash message.
+
+        Args:
+            request: The current incoming request object.
+            message: The message content.
+            title: An optional title shown in the toast header. Defaults to `""`.
+
+        Returns:
+            `True` if the message was stored successfully,
+            `False` if no session is available.
+
+        Example:
+            ```python
+            from sqladmin import Flash
+
+            Flash.warning(request, "Some records could not be processed.")
+            ```
+        """
+        return cls.flash(request, message, FlashLevel.warning, title)
+
+    @classmethod
+    def error(cls, request: Request, message: str, title: str = "") -> bool:
+        """Add an error flash message.
+
+        Args:
+            request: The current incoming request object.
+            message: The message content.
+            title: An optional title shown in the toast header. Defaults to `""`.
+
+        Returns:
+            `True` if the message was stored successfully,
+            `False` if no session is available.
+
+        Example:
+            ```python
+            from sqladmin import Flash
+
+            Flash.error(request, "Access denied. Invalid credentials.", "Error")
+            ```
+        """
+        return cls.flash(request, message, FlashLevel.error, title)
 
 
 def get_flashed_messages(request: Request) -> List[Dict[str, str]]:
+    """Retrieve and clear all stored flash messages from the session.
+
+    Called automatically by the built-in templates. You only need this
+    function if you are writing a fully custom template.
+
+    Args:
+        request: The current incoming request object.
+
+    Returns:
+        A list of dicts, each with keys `message`, `category`, and `title`.
+        Returns an empty list if no session is available or no messages exist.
+
+    Example:
+        ```html
+        {# In a custom Jinja2 template #}
+        {% with messages = get_flashed_messages(request) %}
+          {% for msg in messages %}
+            <div class="alert alert-{{ msg.category }}">{{ msg.message }}</div>
+          {% endfor %}
+        {% endwith %}
+        ```
+    """
     messages: List[Dict[str, str]] = []
     if "session" not in request.scope:
         return messages
@@ -127,8 +199,36 @@ def get_flashed_messages(request: Request) -> List[Dict[str, str]]:
 
 
 def flash(
-    request: Request, message: str, category: str = "primary", title: str = ""
+    request: Request,
+    message: str,
+    category: str = "primary",
+    title: str = "",
 ) -> bool:
+    """Store a flash message directly in the session.
+
+    Low-level function used internally by the `Flash` class methods.
+    Prefer using `Flash.success()`, `Flash.error()` etc. for type-safe
+    level selection. Use this function only when you need to pass a raw
+    Bootstrap color class string as the category.
+
+    Args:
+        request: The current incoming request object.
+        message: The message content.
+        category: A Bootstrap color class string. One of: `"primary"`,
+            `"success"`, `"warning"`, `"danger"`. Defaults to `"primary"`.
+        title: An optional title shown in the toast header. Defaults to `""`.
+
+    Returns:
+        `True` if the message was stored successfully,
+        `False` if no session is available.
+
+    Example:
+        ```python
+        from sqladmin.flash import flash
+
+        flash(request, "Operation completed.", category="success", title="Done")
+        ```
+    """
     if "session" not in request.scope:
         return False
 


### PR DESCRIPTION

The `CONTRIBUTING.md` file exists in the repository root but was not
accessible from the documentation site. New contributors who browse
the docs have no way to find contribution guidelines without knowing
to look in the repo root directly.

## Changes

- `CONTRIBUTING.md` — expanded the existing file with branch naming
  conventions, commit message conventions (Conventional Commits),
  project structure overview, and fork sync instructions
- `docs/contributing.md` — new file added to surface the contributing
  guide on the documentation site
- `mkdocs.yml` — linked the new page in the site navigation

## Why

Surfacing contribution guidelines in the docs lowers the barrier for
new contributors and keeps the information discoverable in one place.