### PR TITLE
fix: authenticate ajax lookup endpoint

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -730,6 +730,11 @@ class Admin(BaseAdminView):
     async def ajax_lookup(self, request: Request) -> Response:
         """Ajax lookup route."""
 
+        if self.authentication_backend is not None:
+            authenticated = await self.authentication_backend.authenticate(request)
+            if not authenticated or isinstance(authenticated, Response):
+                return RedirectResponse(request.url_for("admin:login"), status_code=302)
+
         identity = request.path_params["identity"]
         model_view = self._find_model_view(identity)
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,9 +1,9 @@
 from typing import Generator
 
 import pytest
-from sqlalchemy import Column, Integer
+from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import declarative_base, relationship
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse
@@ -118,3 +118,82 @@ def test_action_access_login_required_views(client: TestClient) -> None:
 
     response = client.get("/admin/movie/action/test")
     assert {"status": "ok"} == response.json()
+
+
+class Artist(Base):
+    __tablename__ = "artists_auth"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(50))
+
+    songs = relationship("SongAuth", back_populates="artist")
+
+    def __str__(self) -> str:
+        return f"Artist {self.id}"
+
+
+class SongAuth(Base):
+    __tablename__ = "songs_auth"
+
+    id = Column(Integer, primary_key=True)
+    artist_id = Column(Integer, ForeignKey("artists_auth.id"))
+
+    artist = relationship("Artist", back_populates="songs")
+
+
+class ArtistAdmin(ModelView, model=Artist):
+    pass
+
+
+class SongAuthAdmin(ModelView, model=SongAuth):
+    form_ajax_refs = {
+        "artist": {
+            "fields": ("name",),
+            "order_by": "name",
+        }
+    }
+
+
+admin.add_view(ArtistAdmin)
+admin.add_view(SongAuthAdmin)
+
+
+@pytest.fixture(autouse=False)
+def prepare_ajax_tables() -> Generator[None, None, None]:
+    Base.metadata.create_all(engine)
+    yield
+    Base.metadata.drop_all(engine)
+
+
+def test_ajax_lookup_unauthenticated_redirects_to_login(
+    client: TestClient,
+) -> None:
+    response = client.get("/admin/song-auth/ajax/lookup?name=artist&term=test")
+    assert response.url == "http://testserver/admin/login"
+
+
+def test_ajax_lookup_authenticated_returns_200(
+    client: TestClient,
+    prepare_ajax_tables: None,
+) -> None:
+    client.post(
+        "/admin/login",
+        data={"username": "a", "password": "b"},
+    )
+
+    response = client.get("/admin/song-auth/ajax/lookup?name=artist&term=test")
+    assert response.status_code == 200
+    assert "results" in response.json()
+
+
+def test_ajax_lookup_after_logout_redirects_to_login(
+    client: TestClient,
+) -> None:
+    client.post(
+        "/admin/login",
+        data={"username": "a", "password": "b"},
+    )
+    client.get("/admin/logout")
+
+    response = client.get("/admin/song-auth/ajax/lookup?name=artist&term=test")
+    assert response.url == "http://testserver/admin/login"


### PR DESCRIPTION


Fixes #1011

The `/{identity}/ajax/lookup` endpoint was publicly accessible without any authentication, allowing unauthenticated users to query model data directly via a URL like:

`/admin/membership/ajax/lookup?name=user&term=test`

## Changes

**`sqladmin/application.py`**
- Added authentication check at the start of `ajax_lookup()`, consistent with how other protected endpoints are handled. Unauthenticated requests are redirected to the login page.

**`tests/test_authentication.py`**
- Added 3 tests covering unauthenticated access, authenticated access, and access after logout.

