### PR TITLE
fix: forward kwargs to SessionMiddleware in AuthenticationBackend

### DIFF
--- a/sqladmin/authentication.py
+++ b/sqladmin/authentication.py
@@ -15,11 +15,11 @@ class AuthenticationBackend:
     `login`, `logout` and `authenticate`.
     """
 
-    def __init__(self, secret_key: str) -> None:
+    def __init__(self, secret_key: str, **session_kwargs: Any) -> None:
         from starlette.middleware.sessions import SessionMiddleware
 
         self.middlewares = [
-            Middleware(SessionMiddleware, secret_key=secret_key),
+            Middleware(SessionMiddleware, secret_key=secret_key, **session_kwargs),
         ]
 
     async def login(self, request: Request) -> bool:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from typing import Generator, Union
 
 import pytest
 from sqlalchemy import Column, Integer
@@ -39,7 +39,7 @@ class CustomBackend(AuthenticationBackend):
         request.session.clear()
         return True
 
-    async def authenticate(self, request: Request) -> bool:
+    async def authenticate(self, request: Request) -> Union[bool, RedirectResponse]:
         if "token" not in request.session:
             return RedirectResponse(request.url_for("admin:login"), status_code=302)
         return True
@@ -118,3 +118,60 @@ def test_action_access_login_required_views(client: TestClient) -> None:
 
     response = client.get("/admin/movie/action/test")
     assert {"status": "ok"} == response.json()
+
+
+def test_custom_session_cookie_name_is_set() -> None:
+    backend = CustomBackend(
+        secret_key="test",
+        session_cookie="my_cookie",
+    )
+    middleware = backend.middlewares[0]
+    assert middleware.kwargs["session_cookie"] == "my_cookie"
+
+
+def test_login_with_custom_session_cookie() -> None:
+    app = Starlette()
+    backend = CustomBackend(
+        secret_key="test",
+        session_cookie="my_cookie",
+    )
+    Admin(app=app, engine=engine, authentication_backend=backend)
+
+    with TestClient(app=app, base_url="http://testserver") as c:
+        response = c.post("/admin/login", data={"username": "a", "password": "b"})
+        assert response.status_code == 200
+        assert "my_cookie" in c.cookies
+        assert "session" not in c.cookies
+
+
+def test_authenticated_request_with_custom_session_cookie() -> None:
+    app = Starlette()
+    backend = CustomBackend(
+        secret_key="test",
+        session_cookie="my_cookie",
+    )
+    Admin(app=app, engine=engine, authentication_backend=backend)
+
+    with TestClient(app=app, base_url="http://testserver") as c:
+        c.post("/admin/login", data={"username": "a", "password": "b"})
+        response = c.get("/admin/")
+        assert response.status_code == 200
+
+
+def test_default_session_cookie_unchanged() -> None:
+    backend = CustomBackend(secret_key="test")
+    middleware = backend.middlewares[0]
+    assert "session_cookie" not in middleware.kwargs
+
+
+def test_extra_session_kwargs_passed_to_middleware() -> None:
+    backend = CustomBackend(
+        secret_key="test",
+        session_cookie="my_cookie",
+        max_age=3600,
+        https_only=True,
+    )
+    middleware = backend.middlewares[0]
+    assert middleware.kwargs["session_cookie"] == "my_cookie"
+    assert middleware.kwargs["max_age"] == 3600
+    assert middleware.kwargs["https_only"] is True


### PR DESCRIPTION
Fixes #1001

`AuthenticationBackend` only accepted `secret_key` and ignored all other `SessionMiddleware` options. When a user configured a custom `session_cookie` name, sqladmin's internal middleware used the default `"session"` cookie name while the app used the custom one, resulting in `request.session` always being empty in the admin context.

## Changes

**`sqladmin/authentication.py`**
- `AuthenticationBackend.__init__` now accepts `**session_kwargs` and forwards them to `SessionMiddleware`, enabling full configuration.

**`tests/test_authentication.py`**
- Added tests covering custom `session_cookie` name, additional kwargs  (`max_age`, `https_only`), and backward compatibility with the default configuration.



```python
# Before - only secret_key was supported
authentication_backend = CustomBackend(secret_key="sqladmin")

# After - all SessionMiddleware options are supported
authentication_backend = CustomBackend(
    secret_key="sqladmin",
    session_cookie="my_cookie_name",
    max_age=3600,
    https_only=True,
)
```
