### PR TITLE
[Fix] AJAX Select2 field. Removed separate fields for each selection.

### DIFF
--- a/sqladmin/statics/js/main.js
+++ b/sqladmin/statics/js/main.js
@@ -98,28 +98,44 @@ $(':input[data-role="datetimepicker"]:not([readonly])').each(function () {
 
 // Ajax Refs
 $(':input[data-role="select2-ajax"]').each(function () {
-  $(this).select2({
+  var placeholderText = $(this).attr("placeholder") || "Search";
+
+  var $select = $(this);
+  var originalName = $select.attr("name");
+  var $hiddenInput = $('<input type="hidden">').attr("name", originalName);
+  $select.after($hiddenInput);
+  $select.removeAttr("name");
+
+  $select.select2({
     minimumInputLength: 1,
+    placeholder: placeholderText,
+    allowClear: true,
     ajax: {
-      url: $(this).data("url"),
+      url: $select.data("url"),
       dataType: 'json',
       data: function (params) {
-        var query = {
-          name: $(this).attr("name"),
+        return {
+          name: originalName,
           term: params.term,
-        }
-        return query;
+        };
       }
     }
   });
 
-  existing_data = $(this).data("json") || [];
-  for (var i = 0; i < existing_data.length; i++) {
-    data = existing_data[i];
+  $select.on('change', function () {
+    var val = $select.val();
+    $hiddenInput.val(val ? val.join(',') : '');
+  });
+
+  var existing_data = $select.data("json") || [];
+  existing_data.forEach(function (data) {
     var option = new Option(data.text, data.id, true, true);
-    $(this).append(option).trigger('change');
-  }
+    $select.append(option);
+  });
+
+  $select.trigger('change');
 });
+
 
 // Checkbox select
 $("#select-all").click(function () {


### PR DESCRIPTION
# https://github.com/smithyhq/sqladmin/issues/1000
# Fix "Too many fields" error for many selection in AJAX

## Before:
<img width="774" height="709" alt="image" src="https://github.com/user-attachments/assets/aeed23a9-0aa7-427a-b820-b4af57791679" />

## After:
<img width="774" height="307" alt="Screenshot from 2026-05-04 11-48-18" src="https://github.com/user-attachments/assets/e95e5998-96e5-4f89-82bb-d432db696002" />

# Details:
* Instead of separate fields for each selection, all AJAX values are passed as a single comma-separated field.
* Added a placeholder.
* Added a "Clear All" button to remove all inputs.