### PR TITLE
Fixed overriding form_args in forms.py and widgets.py

### DIFF
--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -187,7 +187,7 @@ class ModelConverterBase:
                     else callable_default
                 )
 
-        kwargs["default"] = default
+        kwargs.setdefault("default", default)
         optional_types = (Boolean,)
 
         if column.nullable:
@@ -215,7 +215,7 @@ class ModelConverterBase:
             if not pair[0].nullable:
                 nullable = False
 
-        kwargs["allow_blank"] = nullable
+        kwargs.setdefault("allow_blank", nullable)
 
         if not loader:
             kwargs.setdefault(
@@ -375,9 +375,9 @@ class ModelConverter(ModelConverterBase):
             kwargs["render_kw"]["class"] = "form-check-input"
             return BooleanField(**kwargs)
 
-        kwargs["allow_blank"] = True
-        kwargs["choices"] = [(True, "True"), (False, "False")]
-        kwargs["coerce"] = lambda v: str(v) == "True"
+        kwargs.setdefault("allow_blank", True)
+        kwargs.setdefault("choices", [(True, "True"), (False, "False")])
+        kwargs.setdefault("coerce", lambda v: str(v) == "True")
         return SelectField(**kwargs)
 
     @converts("Date")
@@ -421,7 +421,7 @@ class ModelConverter(ModelConverterBase):
         accepted_values = [choice[0] for choice in available_choices]
 
         if prop.columns[0].nullable:
-            kwargs["allow_blank"] = True
+            kwargs.setdefault("allow_blank", True)
             accepted_values.append(None)
             filters = kwargs.get("filters", [])
             filters.append(lambda x: x or None)
@@ -430,7 +430,9 @@ class ModelConverter(ModelConverterBase):
         kwargs["choices"] = available_choices
         kwargs.setdefault("validators", [])
         kwargs["validators"].append(validators.AnyOf(accepted_values))
-        kwargs["coerce"] = lambda v: v.name if isinstance(v, enum.Enum) else str(v)
+        kwargs.setdefault(
+            "coerce", lambda v: v.name if isinstance(v, enum.Enum) else str(v)
+        )
         return SelectField(**kwargs)
 
     @converts("Integer")  # includes BigInteger and SmallInteger
@@ -617,7 +619,7 @@ class ModelConverter(ModelConverterBase):
         ]
 
         if column.nullable:
-            kwargs["allow_blank"] = column.nullable
+            kwargs.setdefault("allow_blank", column.nullable)
             accepted_values.append(None)
             filters = kwargs.get("filters", [])
             filters.append(lambda x: x or None)
@@ -625,7 +627,7 @@ class ModelConverter(ModelConverterBase):
 
         kwargs["choices"] = available_choices
         kwargs["validators"].append(validators.AnyOf(accepted_values))
-        kwargs["coerce"] = choice_type_coerce_factory(column.type)
+        kwargs.setdefault("coerce", choice_type_coerce_factory(column.type))
         return SelectField(**kwargs)
 
     @converts("fastapi_storages.integrations.sqlalchemy.FileType")
@@ -654,6 +656,8 @@ class ModelConverter(ModelConverterBase):
         kwargs: dict[str, Any],
     ) -> UnboundField:
         kwargs["allow_blank"] = True
+
+        # kwargs.setdefault("allow_blank", True)
         return QuerySelectField(**kwargs)
 
     @converts("MANYTOONE")

--- a/sqladmin/widgets.py
+++ b/sqladmin/widgets.py
@@ -49,22 +49,22 @@ class AjaxSelect2Widget(widgets.Select):
 
         allow_blank = getattr(field, "allow_blank", False)
         if allow_blank and not self.multiple:
-            kwargs["data-allow-blank"] = "1"
+            kwargs.setdefault("data-allow-blank", "1")
 
         kwargs.setdefault("id", field.id)
         kwargs.setdefault("type", "hidden")
 
         if self.multiple:
             result = [field.loader.format(value) for value in field.data]
-            kwargs["data-json"] = json.dumps(result)
-            kwargs["multiple"] = "1"
+            kwargs.setdefault("data-json", json.dumps(result))
+            kwargs.setdefault("multiple", "1")
         else:
             try:
                 data = field.loader.format(field.data)
             except Exception:
                 data = None
             if data:
-                kwargs["data-json"] = json.dumps([data])
+                kwargs.setdefault("data-json", json.dumps([data]))
 
         return Markup(f"<select {html_params(name=field.name, **kwargs)}></select>")  # nosec: markupsafe_markup_xss
 
@@ -117,7 +117,7 @@ class BooleanInputWidget(widgets.Input):
 
     def __call__(self, field: Field, **kwargs: Any) -> Markup:
         if field.data:
-            kwargs["checked"] = True
+            kwargs.setdefault("checked", True)
 
         return Markup(
             '<div class="form-switch d-flex align-items-center h-100">%s</div>'

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -183,6 +183,11 @@ class UserAdmin(ModelView, model=User):
         ],
         User.profile_formattable: lambda m, a: f"Formatted {m.profile_formattable}",
     }
+    form_args = {
+        "profile": {
+            "allow_blank": True,
+        },
+    }
     save_as = True
 
 


### PR DESCRIPTION
I stumbled upon this when I wanted to have `allow_blank` to be `True` in one of the fields. However, this was not working:

```python
form_args = {
    "personnel": {
        "allow_blank": True,
        "blank_text": "-- Choose --",
    }
}
```

Because, in sqladmin/forms.py:218:

`kwargs["allow_blank"] = nullable` overrode my param. So, I changed this (and all others) to use `setdefault`: only put values if user has not defined anything.