### PR TITLE
fix(list): fix the list view to limit the page width to viewport size

### DIFF
--- a/sqladmin/statics/css/main.css
+++ b/sqladmin/statics/css/main.css
@@ -8,3 +8,7 @@
     margin-right: 5px;
 }
 
+.min-w-0 {
+    min-width: 0 !important;
+}
+

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -3,8 +3,8 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-12">
-      <div class="d-flex">
-        <div class="flex-grow-1 me-2">
+      <div class="d-flex" style="min-width: 0;">
+        <div class="flex-grow-1 me-2" style="min-width: 0;">
           <div class="card">
             <div class="card-header">
               <h3 class="card-title">{{ model_view.name_plural }}</h3>

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -3,8 +3,8 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-12">
-      <div class="d-flex" style="min-width: 0;">
-        <div class="flex-grow-1 me-2" style="min-width: 0;">
+      <div class="d-flex min-w-0">
+        <div class="flex-grow-1 me-2 min-w-0">
           <div class="card">
             <div class="card-header">
               <h3 class="card-title">{{ model_view.name_plural }}</h3>


### PR DESCRIPTION
Close: #1043

By default, flex items have `min-width: auto`, which causes the browser to calculate their minimum width based on their content. In the list view, the content inside the card container is the table itself.

Before this fix, the card containers inherited the table’s minimum width, causing overflow at the page level. As a result, the table-level `overflow-x: auto` from `.table-responsive` did not take effect.

With this fix, overflow is now correctly handled at the table level.