### PR TITLE
fix: render column defaults on the create form

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -624,6 +624,17 @@ class Admin(BaseAdminView):
         model_view = self._find_model_view(identity)
 
         Form = await model_view.scaffold_form(model_view._form_create_rules)
+
+        if request.method == "GET":
+            form = Form()
+            context = {
+                "model_view": model_view,
+                "form": form,
+            }
+            return await self.templates.TemplateResponse(
+                request, model_view.create_template, context
+            )
+
         form_data = await self._handle_form_data(request)
         form = Form(form_data)
 
@@ -631,11 +642,6 @@ class Admin(BaseAdminView):
             "model_view": model_view,
             "form": form,
         }
-
-        if request.method == "GET":
-            return await self.templates.TemplateResponse(
-                request, model_view.create_template, context
-            )
 
         if not form.validate():
             return await self.templates.TemplateResponse(

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -143,7 +143,6 @@ class ModelConverterBase:
         kwargs.setdefault("label", label)
         kwargs.setdefault("validators", [])
         kwargs.setdefault("filters", [])
-        kwargs.setdefault("default", None)
         kwargs.setdefault("description", prop.doc)
         kwargs.setdefault("render_kw", widget_args)
 

--- a/sqladmin/forms.py
+++ b/sqladmin/forms.py
@@ -155,6 +155,10 @@ class ModelConverterBase:
                 prop=prop, session_maker=session_maker, kwargs=kwargs, loader=loader
             )
 
+        # Fallback so kwargs always has "default"; column defaults set above win.
+        if kwargs is not None:
+            kwargs.setdefault("default", None)
+
         return kwargs
 
     def _prepare_column(

--- a/tests/test_forms/test_forms.py
+++ b/tests/test_forms/test_forms.py
@@ -337,7 +337,7 @@ async def test_model_field_clashing_with_wtforms_reserved_attribute() -> None:
     class DataModel(Base):
         __tablename__ = "model_with_wtforms_reserved_attribute"
         id = Column(Integer, primary_key=True)
-        data = Column(String)
+        data = Column(String, default="untitled")
         errors = Column(String)
         process = Column(String)
         validate = Column(Boolean)
@@ -358,6 +358,7 @@ async def test_model_field_clashing_with_wtforms_reserved_attribute() -> None:
     assert Form.process_.name == "process"
     assert Form.validate_.name == "validate"
     assert Form.populate_obj_.name == "populate_obj"
+    assert Form()._fields["data_"].default == "untitled"
     assert isinstance(Form.data, property)
     assert isinstance(Form.errors, property)
     assert isinstance(form.data, dict)

--- a/tests/test_forms/test_forms.py
+++ b/tests/test_forms/test_forms.py
@@ -159,6 +159,36 @@ async def test_model_form_form_args() -> None:
     assert Form()._fields["number"].default == 100
 
 
+async def test_model_form_column_default() -> None:
+    class Model(Base):
+        __tablename__ = "model_column_default"
+
+        id = Column(Integer, primary_key=True)
+        name = Column(String, default="untitled")
+        priority = Column(Integer, default=5)
+        is_active = Column(Boolean, nullable=False, default=True)
+
+    Form = await get_model_form(model=Model, session_maker=session_maker)
+    assert Form()._fields["name"].default == "untitled"
+    assert Form()._fields["priority"].default == 5
+    assert Form()._fields["is_active"].default is True
+
+
+async def test_model_form_form_args_default_overrides_column() -> None:
+    class Model(Base):
+        __tablename__ = "model_form_args_overrides_column_default"
+
+        id = Column(Integer, primary_key=True)
+        name = Column(String, default="from-column")
+
+    Form = await get_model_form(
+        model=Model,
+        session_maker=session_maker,
+        form_args={"name": {"default": "from-form-args"}},
+    )
+    assert Form()._fields["name"].default == "from-form-args"
+
+
 async def test_model_form_column_label() -> None:
     labels = {"name": "User Name"}
     Form = await get_model_form(

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -164,6 +164,15 @@ class EachRowAction(Base):
     can_delete = Column(Boolean, nullable=True, default=True)
 
 
+class WithDefaults(Base):
+    __tablename__ = "with_defaults"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, default="untitled")
+    priority = Column(Integer, default=5)
+    is_active = Column(Boolean, nullable=False, default=True)
+
+
 @pytest.fixture(autouse=True)
 async def prepare_database() -> AsyncGenerator[None, None]:
     async with engine.begin() as conn:
@@ -271,6 +280,10 @@ class PersonAdmin(ModelView, model=Person):
     form_columns = [Person.name]
 
 
+class WithDefaultsAdmin(ModelView, model=WithDefaults):
+    pass
+
+
 admin.add_view(UserAdmin)
 admin.add_view(AddressAdmin)
 admin.add_view(ProfileAdmin)
@@ -278,6 +291,7 @@ admin.add_view(MovieAdmin)
 admin.add_view(EachRowActionAdmin)
 admin.add_view(ProductAdmin)
 admin.add_view(PersonAdmin)
+admin.add_view(WithDefaultsAdmin)
 
 
 async def test_root_view(client: AsyncClient) -> None:
@@ -569,6 +583,42 @@ async def test_create_endpoint_with_required_fields(client: AsyncClient) -> None
         '<label class="form-label col-sm-2 col-form-label" for="price">Price</label>'
         in response.text
     )
+
+
+async def test_create_endpoint_renders_column_defaults(client: AsyncClient) -> None:
+    response = await client.get("/admin/with-defaults/create")
+
+    assert response.status_code == 200
+    assert (
+        '<input class="form-control" id="name" name="name" type="text"'
+        ' value="untitled">' in response.text
+    )
+    assert (
+        '<input class="form-control" id="priority" name="priority" type="number"'
+        ' value="5">' in response.text
+    )
+    assert (
+        '<input checked class="form-check-input" id="is_active" name="is_active"'
+        ' type="checkbox" value="y">' in response.text
+    )
+
+
+async def test_create_endpoint_post_unchecked_overrides_default(
+    client: AsyncClient,
+) -> None:
+    data = {"name": "foo", "priority": "3"}
+    response = await client.post(
+        "/admin/with-defaults/create", data=data, follow_redirects=False
+    )
+
+    assert response.status_code == 302
+
+    async with session_maker() as session:
+        result = await session.execute(select(WithDefaults))
+        row = result.scalars().one()
+    assert row.is_active is False
+    assert row.name == "foo"
+    assert row.priority == 3
 
 
 async def test_check_can_view_details(client: AsyncClient) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1551,7 +1551,7 @@ wheels = [
 
 [[package]]
 name = "sqladmin"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Closes #1060

Two stacked bugs prevented column-level field defaults from rendering on the create form:

1. Column defaults (e.g. `Column(default=True)`) never reached the form fields - `sqladmin` was overwriting them with `None` while building each field, so the column's own default was always discarded.
2. `application.py:create` always passed formdata to `Form()`, even on GET. WTForms treats an empty `FormData` as a real submission, so `BooleanField` / `SelectMultipleField`'s `process_formdata` then overwrites the default with `False` / `[]` before render.

Removing the early `setdefault` lets column defaults flow through `_prepare_column` for every field type. Skipping formdata on GET lets WTForms fall back to those defaults at render time.

Tests cover both layers: a unit test that checks `field.default` is populated from the column, plus end-to-end render tests on the GET create page for string, integer, and non-nullable boolean columns. There is also a test that submits the create form with the checkbox unchecked, to make sure defaults don't override real submissions.