### PR TITLE
fix(base-view): sidebar link falls back to /admin when @expose method is named index

### DIFF
--- a/sqladmin/_menu.py
+++ b/sqladmin/_menu.py
@@ -74,7 +74,7 @@ class ViewMenu(ItemMenu):
     def url(self, request: Request) -> str | URL:
         if self.view.is_model:
             return request.url_for("admin:list", identity=self.view.identity)
-        return request.url_for(f"admin:{self.view.identity}")
+        return request.url_for(f"admin:view-{self.view.identity}")
 
     @property
     def display_name(self) -> str:

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -220,7 +220,7 @@ class BaseAdmin:
             else:
                 view.identity = getattr(func, "_identity")
                 path = getattr(func, "_path")
-                name = getattr(func, "_identity")
+                name = f"view-{view.identity}"
 
             self.admin.add_route(
                 route=func,

--- a/tests/test_base_view.py
+++ b/tests/test_base_view.py
@@ -61,3 +61,30 @@ def test_menu_view_url(client: TestClient) -> None:
     assert (
         '<a class="nav-link " href="http://testserver/admin/custom">' in response.text
     )
+
+
+class IndexNamedView(BaseView):
+    name = "Activity Analytics"
+    icon = "fa fa-chart"
+
+    @expose("/activity-analytics", methods=["GET"])
+    async def index(self, request: Request):
+        return await self.templates.TemplateResponse(request, "custom.html")
+
+
+def test_menu_view_url_with_index_method(client: TestClient) -> None:
+    # Regression test for #1057: a BaseView whose first `@expose` method is
+    # named `index` used to register a route named `admin:index`, colliding
+    # with the built-in index route. The sidebar link then resolved to the
+    # admin root (`/admin`) instead of the exposed path.
+    admin.add_view(IndexNamedView)
+
+    response = client.get("/admin/activity-analytics")
+    assert response.status_code == 200
+
+    response = client.get("/admin")
+    assert response.status_code == 200
+    assert (
+        '<a class="nav-link " href="http://testserver/admin/activity-analytics">'
+        in response.text
+    )


### PR DESCRIPTION
## Summary

Fixes #1057.

When a `BaseView` subclass has its first `@expose` method named `index`, sqladmin registered the route under the name `admin:index` — colliding with the built-in admin index route. The subsequent `url_for("admin:index")` call in the sidebar menu then resolved to `/admin` (the root) instead of the view's actual exposed path.

### Root cause

In `application.py`, `_handle_expose_decorated_func` set the route name for non-model views to the raw identity string (e.g. `"index"`), not a namespaced name. A `BaseView` with an `@expose` method named `index` and no explicit `identity` therefore produced:

```
route name: admin:index   ← collides with the built-in index route
```

In `_menu.py`, `ViewMenu.url` called `request.url_for(f"admin:{self.view.identity}")`, which resolved to the wrong route.

### Fix

- **`application.py`**: prefix BaseView route names with `view-`, producing `admin:view-<identity>` instead of `admin:<identity>`.
- **`_menu.py`**: update `ViewMenu.url` to call `request.url_for(f"admin:view-{self.view.identity}")`, consistent with the new naming.

This matches what model views already do (`admin:view-<identity>-<method>`), and is a non-breaking change since these route names are internal.

### Tests

Added `test_menu_view_url_with_index_method` — registers a `BaseView` whose `@expose` method is named `index`, then asserts:
1. The view's own page loads (`/admin/activity-analytics` → 200).
2. The built-in admin index still loads (`/admin` → 200).
3. The sidebar link href points to `/admin/activity-analytics`, not `/admin`.

## Checklist

- [x] Fix is minimal and targeted — no unrelated changes
- [x] Regression test added
- [x] Existing test suite still passes