### PR TITLE
Preserve list page after editing a record (#1055)

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -814,7 +814,10 @@ class Admin(BaseAdminView):
         identifier = get_object_identifier(obj)
 
         if form.get("save") == "Save":
-            return request.url_for("admin:list", identity=identity)
+            url = URL(str(request.url_for("admin:list", identity=identity)))
+            if request.url.query:
+                url = url.replace(query=request.url.query)
+            return url
 
         if form.get("save") == "Save and continue editing" or (
             form.get("save") == "Save as new" and model_view.save_as_continue

--- a/sqladmin/templates/sqladmin/edit.html
+++ b/sqladmin/templates/sqladmin/edit.html
@@ -8,7 +8,7 @@
     </div>
     <div class="card-body border-bottom py-3">
       {% block edit_form %}
-      <form action="{{ model_view._build_url_for('admin:edit', request, obj) }}" method="POST"
+      <form action="{{ model_view._build_url_for('admin:edit', request, obj) }}{% if request.url.query %}?{{ request.url.query }}{% endif %}" method="POST"
         enctype="multipart/form-data">
         <div class="row">
           {% if error %}
@@ -20,7 +20,7 @@
         </fieldset>
         <div class="row">
           <div class="col-md-2">
-            <a href="{{ url_for('admin:list', identity=model_view.identity) }}" class="btn">
+            <a href="{{ url_for('admin:list', identity=model_view.identity) }}{% if request.url.query %}?{{ request.url.query }}{% endif %}" class="btn">
               Cancel
             </a>
           </div>

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -143,7 +143,7 @@
                       </a>
                       {% endif %}
                       {% if model_view.check_can_edit(request, row) %}
-                      <a href="{{ model_view._build_url_for('admin:edit', request, row) }}" data-bs-toggle="tooltip"
+                      <a href="{{ model_view._build_url_for('admin:edit', request, row) }}{% if request.url.query %}?{{ request.url.query }}{% endif %}" data-bs-toggle="tooltip"
                         data-bs-placement="top" title="Edit">
                         <span class="me-1"><i class="fa-solid fa-pen-to-square"></i></span>
                       </a>

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -151,6 +151,16 @@ def test_get_save_redirect_url():
     response = client.post("/user", data={"save": "Save and add another"})
     assert response.text == "http://testserver/admin/user/create"
 
+    # Issue #1055: the list query string (page, sorting, search) should be
+    # preserved on "Save" so the user returns to the page they came from.
+    response = client.post("/user?page=3", data={"save": "Save"})
+    assert response.text == "http://testserver/admin/user/list?page=3"
+
+    # The query string only matters for the list redirect; the other actions
+    # go to fixed edit/create pages and should ignore it.
+    response = client.post("/user?page=3", data={"save": "Save and continue editing"})
+    assert response.text == "http://testserver/admin/user/edit/1"
+
 
 def test_build_category_menu():
     app = Starlette()


### PR DESCRIPTION
## What this does

Fixes #1055.

Right now if you are on page 3 of a list view and edit a record, after pressing **Save** you always get sent back to page 1. If you are working through a long list this is annoying because you lose your place every time.

This PR keeps the list query string (the `page`, and also sorting/search params since they live in the same query string) while you edit, and uses it for the redirect after saving, so you end up back on the page you came from.

## How

The page info was getting dropped at a few points, so I carried it through the whole flow:

- **`list.html`** – the Edit link now appends the current list query string, so opening the edit page keeps `?page=3`.
- **`edit.html`** – the form `action` and the Cancel link keep the same query string, so the POST happens on `.../edit/{pk}?page=3`.
- **`get_save_redirect_url`** – on the `Save` action it now reuses `request.url.query` when building the list URL. The other actions (continue editing / save as new / add another) are unchanged.

Only the `Save` action reads the query string; the others go to fixed edit/create pages so they ignore it.

## Tests

Extended `test_get_save_redirect_url` to check that `Save` keeps `?page=3` and that `Save and continue editing` still goes to the edit page regardless. Full test suite passes locally, and `ruff` / `ruff format` / `mypy` are clean.