### PR TITLE
fix: follow symlinks for static files

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -418,6 +418,7 @@ class Admin(BaseAdminView):
         debug: bool = False,
         templates_dir: str = "templates",
         authentication_backend: AuthenticationBackend | None = None,
+        static_files_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
         Args:
@@ -430,6 +431,7 @@ class Admin(BaseAdminView):
             logo_width: Width of the logo image in pixels. Defaults to 64.
             logo_height: Height of the logo image in pixels. Defaults to 64.
             favicon_url: URL of favicon to be displayed.
+            static_files_kwargs: Extra keyword arguments for Starlette StaticFiles.
         """
 
         super().__init__(
@@ -447,7 +449,9 @@ class Admin(BaseAdminView):
             authentication_backend=authentication_backend,
         )
 
-        statics = StaticFiles(packages=["sqladmin"], follow_symlink=True)
+        statics = StaticFiles(
+            **{"packages": ["sqladmin"], **(static_files_kwargs or {})}
+        )
 
         async def http_exception(
             request: Request, exc: Exception

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -447,7 +447,7 @@ class Admin(BaseAdminView):
             authentication_backend=authentication_backend,
         )
 
-        statics = StaticFiles(packages=["sqladmin"])
+        statics = StaticFiles(packages=["sqladmin"], follow_symlink=True)
 
         async def http_exception(
             request: Request, exc: Exception

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -449,9 +449,8 @@ class Admin(BaseAdminView):
             authentication_backend=authentication_backend,
         )
 
-        statics = StaticFiles(
-            **{"packages": ["sqladmin"], **(static_files_kwargs or {})}
-        )
+        static_files_kwargs = {**(static_files_kwargs or {}), "packages": ["sqladmin"]}
+        statics = StaticFiles(**static_files_kwargs)
 
         async def http_exception(
             request: Request, exc: Exception

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -119,17 +119,37 @@ def test_middlewares() -> None:
     assert "x-correlation-id" in response.headers
 
 
-def test_static_files_follow_symlink() -> None:
-    """Issue #863: package statics must follow symlinks (uv symlink mode)."""
-    app = Starlette()
-    admin = Admin(app=app, engine=engine)
-
+def _get_statics_mount(admin: Admin) -> Mount:
     statics_mount = next(
         route
         for route in admin.admin.router.routes
         if isinstance(route, Mount) and route.name == "statics"
     )
     assert isinstance(statics_mount.app, StaticFiles)
+    return statics_mount
+
+
+def test_static_files_use_default_kwargs() -> None:
+    app = Starlette()
+    admin = Admin(app=app, engine=engine)
+
+    statics_mount = _get_statics_mount(admin)
+
+    assert statics_mount.app.follow_symlink is False
+    assert statics_mount.app.packages == ["sqladmin"]
+
+
+def test_static_files_accept_custom_kwargs() -> None:
+    """Issue #863: package statics can opt into following symlinks."""
+    app = Starlette()
+    admin = Admin(
+        app=app,
+        engine=engine,
+        static_files_kwargs={"follow_symlink": True},
+    )
+
+    statics_mount = _get_statics_mount(admin)
+
     assert statics_mount.app.follow_symlink is True
     assert statics_mount.app.packages == ["sqladmin"]
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -154,6 +154,19 @@ def test_static_files_accept_custom_kwargs() -> None:
     assert statics_mount.app.packages == ["sqladmin"]
 
 
+def test_static_files_kwargs_cannot_override_packages() -> None:
+    app = Starlette()
+    admin = Admin(
+        app=app,
+        engine=engine,
+        static_files_kwargs={"packages": ["not_sqladmin"]},
+    )
+
+    statics_mount = _get_statics_mount(admin)
+
+    assert statics_mount.app.packages == ["sqladmin"]
+
+
 def test_get_save_redirect_url():
     async def index(request: Request):
         obj = User(id=1)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -8,7 +8,8 @@ from starlette.datastructures import MutableHeaders
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import Route
+from starlette.routing import Mount, Route
+from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -116,6 +117,21 @@ def test_middlewares() -> None:
 
     assert response.status_code == 200
     assert "x-correlation-id" in response.headers
+
+
+def test_static_files_follow_symlink() -> None:
+    """Issue #863: package statics must follow symlinks (uv symlink mode)."""
+    app = Starlette()
+    admin = Admin(app=app, engine=engine)
+
+    statics_mount = next(
+        route
+        for route in admin.admin.router.routes
+        if isinstance(route, Mount) and route.name == "statics"
+    )
+    assert isinstance(statics_mount.app, StaticFiles)
+    assert statics_mount.app.follow_symlink is True
+    assert statics_mount.app.packages == ["sqladmin"]
 
 
 def test_get_save_redirect_url():


### PR DESCRIPTION
## Summary

Fixes static file access when SQLAdmin is installed in an environment where package files are symlinked, such as `uv` with `UV_LINK_MODE=symlink`.

SQLAdmin mounts Starlette `StaticFiles` for package statics. Starlette defaults `follow_symlink=False`, which can prevent package static assets from being served when the installed package path contains symlinks.

This change sets `follow_symlink=True` for SQLAdmin's static files mount.

## Tests

- `uv run pytest tests/test_application.py -q`
- `uv run pytest tests -q`
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy sqladmin`

Fixes #863