### PR TITLE
fix: preserve base admin identity for polymorphic rows

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -791,9 +791,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
     def _url_for_delete(self, request: Request, obj: Any) -> str:
         pk = get_object_identifier(obj)
         query_params = urlencode({"pks": pk})
-        url = request.url_for(
-            "admin:delete", identity=slugify_class_name(obj.__class__.__name__)
-        )
+        url = request.url_for("admin:delete", identity=self.identity)
         return str(url) + "?" + query_params
 
     def _url_for_details_with_prop(self, request: Request, obj: Any, prop: str) -> URL:
@@ -804,6 +802,13 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
 
     def _url_for_action(self, request: Request, action_name: str) -> str:
         return str(request.url_for(f"admin:action-{self.identity}-{action_name}"))
+
+    def _build_url_for_current_view(self, name: str, request: Request, obj: Any) -> URL:
+        return request.url_for(
+            name,
+            identity=self.identity,
+            pk=get_object_identifier(obj),
+        )
 
     def _build_url_for(self, name: str, request: Request, obj: Any) -> URL:
         return request.url_for(

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -791,6 +791,16 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
     def _url_for_delete(self, request: Request, obj: Any) -> str:
         pk = get_object_identifier(obj)
         query_params = urlencode({"pks": pk})
+        url = request.url_for(
+            "admin:delete", identity=slugify_class_name(obj.__class__.__name__)
+        )
+        return str(url) + "?" + query_params
+
+    # TODO: Merge current-view URL helpers into the legacy helpers in the next
+    # breaking-change window.
+    def _url_for_delete_current_view(self, request: Request, obj: Any) -> str:
+        pk = get_object_identifier(obj)
+        query_params = urlencode({"pks": pk})
         url = request.url_for("admin:delete", identity=self.identity)
         return str(url) + "?" + query_params
 

--- a/sqladmin/templates/sqladmin/details.html
+++ b/sqladmin/templates/sqladmin/details.html
@@ -59,7 +59,7 @@
           {% if model_view.check_can_delete(request, model) %}
           <div class="col-auto">
             <a href="#" data-name="{{ model_view.name }}" data-pk="{{ get_object_identifier(model) }}"
-              data-url="{{ model_view._url_for_delete(request, model) }}" data-bs-toggle="modal"
+              data-url="{{ model_view._url_for_delete_current_view(request, model) }}" data-bs-toggle="modal"
               data-bs-target="#modal-delete" class="btn btn-danger">
               Delete
             </a>

--- a/sqladmin/templates/sqladmin/details.html
+++ b/sqladmin/templates/sqladmin/details.html
@@ -67,7 +67,7 @@
           {% endif %}
           {% if model_view.check_can_edit(request, model) %}
           <div class="col-auto">
-            <a href="{{ model_view._build_url_for('admin:edit', request, model) }}" class="btn btn-primary">
+            <a href="{{ model_view._build_url_for_current_view('admin:edit', request, model) }}" class="btn btn-primary">
               Edit
             </a>
           </div>

--- a/sqladmin/templates/sqladmin/edit.html
+++ b/sqladmin/templates/sqladmin/edit.html
@@ -8,7 +8,7 @@
     </div>
     <div class="card-body border-bottom py-3">
       {% block edit_form %}
-      <form action="{{ model_view._build_url_for('admin:edit', request, obj) }}{% if request.url.query %}?{{ request.url.query }}{% endif %}" method="POST"
+      <form action="{{ model_view._build_url_for_current_view('admin:edit', request, obj) }}{% if request.url.query %}?{{ request.url.query }}{% endif %}" method="POST"
         enctype="multipart/form-data">
         <div class="row">
           {% if error %}

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -150,7 +150,7 @@
                       {% endif %}
                       {% if model_view.check_can_delete(request, row) %}
                       <a href="#" data-name="{{ model_view.name }}" data-pk="{{ get_object_identifier(row) }}"
-                        data-url="{{ model_view._url_for_delete(request, row) }}" data-bs-toggle="modal"
+                        data-url="{{ model_view._url_for_delete_current_view(request, row) }}" data-bs-toggle="modal"
                         data-bs-target="#modal-delete">
                         <span data-bs-toggle="tooltip" data-bs-placement="top" title="Delete">
                           <span class="me-1"><i class="fa-solid fa-trash"></i></span>

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -137,13 +137,13 @@
                     </td>
                     <td class="text-end">
                       {% if model_view.check_can_view_details(request, row) %}
-                      <a href="{{ model_view._build_url_for('admin:details', request, row) }}" data-bs-toggle="tooltip"
+                      <a href="{{ model_view._build_url_for_current_view('admin:details', request, row) }}" data-bs-toggle="tooltip"
                         data-bs-placement="top" title="View">
                         <span class="me-1"><i class="fa-solid fa-eye"></i></span>
                       </a>
                       {% endif %}
                       {% if model_view.check_can_edit(request, row) %}
-                      <a href="{{ model_view._build_url_for('admin:edit', request, row) }}{% if request.url.query %}?{{ request.url.query }}{% endif %}" data-bs-toggle="tooltip"
+                      <a href="{{ model_view._build_url_for_current_view('admin:edit', request, row) }}{% if request.url.query %}?{{ request.url.query }}{% endif %}" data-bs-toggle="tooltip"
                         data-bs-placement="top" title="Edit">
                         <span class="me-1"><i class="fa-solid fa-pen-to-square"></i></span>
                       </a>

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -31,6 +31,28 @@ class User(Base):
     name = Column(String(32), default="SQLAdmin")
 
 
+class PinnedObject(Base):
+    __tablename__ = "pinned_objects"
+
+    id = Column(Integer, primary_key=True)
+    pinnedable_type = Column(String)
+
+    __mapper_args__ = {
+        "polymorphic_identity": "pinned_object",
+        "polymorphic_on": pinnedable_type,
+    }
+
+
+class NewsPinned(PinnedObject):
+    __mapper_args__ = {"polymorphic_identity": "news_pinned"}
+
+
+class RelatedModel(Base):
+    __tablename__ = "related_models"
+
+    id = Column(Integer, primary_key=True)
+
+
 @pytest.fixture(autouse=True)
 def prepare_database() -> Generator[None, None, None]:
     Base.metadata.create_all(engine)
@@ -218,6 +240,43 @@ def test_validate_page_and_page_size():
 
     response = client.get("/admin/user/list?page=aaaa")
     assert response.status_code == 400
+
+
+def test_polymorphic_model_urls_use_view_identity() -> None:
+    app = Starlette()
+    admin = Admin(app=app, engine=engine)
+
+    class PinnedObjectAdmin(ModelView, model=PinnedObject): ...
+
+    admin.add_view(PinnedObjectAdmin)
+    view = admin.views[0]
+    obj = NewsPinned(id=1)
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": [(b"host", b"testserver")],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "root_path": "",
+            "app": app,
+        }
+    )
+
+    assert str(view._build_url_for_current_view("admin:edit", request, obj)) == (
+        "http://testserver/admin/pinned-object/edit/1"
+    )
+    assert view._url_for_delete(request, obj) == (
+        "http://testserver/admin/pinned-object/delete?pks=1"
+    )
+    assert str(view._build_url_for("admin:details", request, RelatedModel(id=2))) == (
+        "http://testserver/admin/related-model/details/2"
+    )
 
 
 def test_is_list_template_global():

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 import pytest
 from sqlalchemy import Column, Integer, String
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import declarative_base, sessionmaker
 from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
 from starlette.middleware import Middleware
@@ -16,6 +16,7 @@ from sqladmin import Admin, ModelView
 from tests.common import sync_engine as engine
 
 Base = declarative_base()  # type: ignore
+session_maker = sessionmaker(bind=engine)
 
 
 class DataModel(Base):
@@ -45,12 +46,6 @@ class PinnedObject(Base):
 
 class NewsPinned(PinnedObject):
     __mapper_args__ = {"polymorphic_identity": "news_pinned"}
-
-
-class RelatedModel(Base):
-    __tablename__ = "related_models"
-
-    id = Column(Integer, primary_key=True)
 
 
 @pytest.fixture(autouse=True)
@@ -242,7 +237,43 @@ def test_validate_page_and_page_size():
     assert response.status_code == 400
 
 
-def test_polymorphic_model_urls_use_view_identity() -> None:
+def test_polymorphic_model_pages_use_view_identity() -> None:
+    app = Starlette()
+    admin = Admin(app=app, engine=engine)
+
+    class PinnedObjectAdmin(ModelView, model=PinnedObject):
+        column_list = [PinnedObject.id]
+
+    admin.add_view(PinnedObjectAdmin)
+
+    with session_maker() as session:
+        session.add(NewsPinned(id=1))
+        session.commit()
+
+    client = TestClient(app)
+
+    response = client.get("/admin/pinned-object/list")
+    assert response.status_code == 200
+    assert 'href="http://testserver/admin/pinned-object/details/1"' in response.text
+    assert 'href="http://testserver/admin/pinned-object/edit/1"' in response.text
+    assert (
+        'data-url="http://testserver/admin/pinned-object/delete?pks=1"' in response.text
+    )
+    assert "/admin/news-pinned/" not in response.text
+
+    response = client.get("/admin/pinned-object/details/1")
+    assert response.status_code == 200
+    assert (
+        'data-url="http://testserver/admin/pinned-object/delete?pks=1"' in response.text
+    )
+    assert 'href="http://testserver/admin/pinned-object/edit/1"' in response.text
+
+    response = client.get("/admin/pinned-object/edit/1")
+    assert response.status_code == 200
+    assert 'action="http://testserver/admin/pinned-object/edit/1"' in response.text
+
+
+def test_polymorphic_delete_helper_preserves_object_identity() -> None:
     app = Starlette()
     admin = Admin(app=app, engine=engine)
 
@@ -250,33 +281,16 @@ def test_polymorphic_model_urls_use_view_identity() -> None:
 
     admin.add_view(PinnedObjectAdmin)
     view = admin.views[0]
-    obj = NewsPinned(id=1)
-    request = Request(
-        {
-            "type": "http",
-            "http_version": "1.1",
-            "method": "GET",
-            "scheme": "http",
-            "path": "/",
-            "raw_path": b"/",
-            "query_string": b"",
-            "headers": [(b"host", b"testserver")],
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-            "root_path": "",
-            "app": app,
-        }
-    )
 
-    assert str(view._build_url_for_current_view("admin:edit", request, obj)) == (
-        "http://testserver/admin/pinned-object/edit/1"
-    )
-    assert view._url_for_delete(request, obj) == (
-        "http://testserver/admin/pinned-object/delete?pks=1"
-    )
-    assert str(view._build_url_for("admin:details", request, RelatedModel(id=2))) == (
-        "http://testserver/admin/related-model/details/2"
-    )
+    async def index(request: Request) -> Response:
+        return Response(view._url_for_delete(request, NewsPinned(id=1)))
+
+    app.add_route("/delete-url", index)
+
+    client = TestClient(app)
+    response = client.get("/delete-url")
+
+    assert response.text == "http://testserver/admin/news-pinned/delete?pks=1"
 
 
 def test_is_list_template_global():


### PR DESCRIPTION
Fix polymorphic model row links so they keep using the registered admin view identity.
When a ModelView is registered for a base model, SQLAdmin currently builds edit/details/delete URLs from obj.__class__.__name__. For polymorphic rows, that produces the subclass identity in the URL even though the admin view was registered under the base model identity. The generated link can then point at a route that does not exist and return 404.
This change keeps related-object links using the related object's identity, but makes current-view row action URLs use the registered admin view identity.
Fixes #876
What Changed
add a dedicated helper for current-view row URLs
keep ModelView._build_url_for() for related-object links
update ModelView._url_for_delete() to use the current view identity
update the list/details/edit templates to use the current-view helper for row actions
add a regression test covering a base-model admin rendering a polymorphic subclass row
Validation
.venv\Scripts\python.exe -m pytest -q