### PR TITLE
feat: pass request to column formatters

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -137,6 +137,17 @@ The options available are:
         column_filterable_list = [User.is_admin]
     ```
 
+    Formatters may accept either `(model, attribute)` or `(model, attribute, request)`.
+
+    ```python
+    class UserAdmin(ModelView, model=User):
+        column_formatters = {
+            User.name: lambda m, a, r: r.url_for(
+                "admin:details", identity="user", pk=m.id
+            )
+        }
+    ```
+
 !!! tip
 
     You can use the special keyword `"__all__"` in `column_list` or `column_details_list`
@@ -278,6 +289,8 @@ The options available are:
         column_details_list = [User.id, User.name, "address.zip_code"]
         column_formatters_detail = {User.name: lambda m, a: m.name[:10]}
     ```
+
+    Formatters may accept either `(model, attribute)` or `(model, attribute, request)`.
 
 !!! tip
 

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -747,7 +747,9 @@ class Admin(BaseAdminView):
         rows = await model_view.get_model_objects(
             request=request, limit=model_view.export_max_rows
         )
-        return await model_view.export_data(rows, export_type=export_type)
+        return await model_view.export_data(
+            rows, export_type=export_type, request=request
+        )
 
     async def login(self, request: Request) -> Response:
         if self.authentication_backend is None:

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -733,6 +733,12 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         self._detail_formatters = self._build_column_pairs(
             self.column_formatters_detail
         )
+        self._list_formatter_accepts_request = self._build_formatter_request_support(
+            self._list_formatters
+        )
+        self._detail_formatter_accepts_request = self._build_formatter_request_support(
+            self._detail_formatters
+        )
 
         self._form_prop_names = self.get_form_columns()
         self._form_relation_names = [
@@ -852,14 +858,23 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
 
         return positional_count >= 3
 
+    def _build_formatter_request_support(
+        self, formatters: Dict[str, Callable[..., Any]]
+    ) -> Dict[str, bool]:
+        return {
+            prop: self._formatter_accepts_request(formatter)
+            for prop, formatter in formatters.items()
+        }
+
     def _call_formatter(
         self,
         formatter: Callable[..., Any],
         obj: Any,
         prop: str,
         request: Request | None = None,
+        accepts_request: bool = False,
     ) -> Any:
-        if request is not None and self._formatter_accepts_request(formatter):
+        if request is not None and accepts_request:
             return formatter(obj, prop, request)
 
         return formatter(obj, prop)
@@ -1001,7 +1016,13 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         value = await self.get_prop_value(obj, prop)
         formatter = self._list_formatters.get(prop)
         formatted_value = (
-            self._call_formatter(formatter, obj, prop, request)
+            self._call_formatter(
+                formatter,
+                obj,
+                prop,
+                request,
+                self._list_formatter_accepts_request.get(prop, False),
+            )
             if formatter
             else self._default_formatter(value)
         )
@@ -1015,7 +1036,13 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         value = await self.get_prop_value(obj, prop)
         formatter = self._detail_formatters.get(prop)
         formatted_value = (
-            self._call_formatter(formatter, obj, prop, request)
+            self._call_formatter(
+                formatter,
+                obj,
+                prop,
+                request,
+                self._detail_formatter_accepts_request.get(prop, False),
+            )
             if formatter
             else self._default_formatter(value)
         )
@@ -1354,10 +1381,11 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         self,
         data: List[Any],
         export_type: str = "csv",
+        request: Request | None = None,
     ) -> StreamingResponse:
         if export_type == "csv":
             export_method = (
-                PrettyExport.pretty_export_csv(self, data)
+                PrettyExport.pretty_export_csv(self, data, request=request)
                 if self.use_pretty_export
                 else self._export_csv(data)
             )

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect as inspect_module
 import json
 import time
 import warnings
@@ -267,7 +268,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         ```
     """
 
-    column_formatters: ClassVar[Dict[MODEL_ATTR, Callable[[type, Column], Any]]] = {}
+    column_formatters: ClassVar[Dict[MODEL_ATTR, Callable[..., Any]]] = {}
     """Dictionary of list view column formatters.
     Columns can either be string names or SQLAlchemy columns.
 
@@ -280,9 +281,10 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
     The format function has the prototype:
     ???+ formatter
         ```python
-        def formatter(model, attribute):
+        def formatter(model, attribute, request):
             # `model` is model instance
             # `attribute` is a Union[ColumnProperty, RelationshipProperty]
+            # `request` is a starlette.requests.Request
             pass
         ```
     """
@@ -402,9 +404,7 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         ```
     """
 
-    column_formatters_detail: ClassVar[
-        Dict[MODEL_ATTR, Callable[[type, Column], Any]]
-    ] = {}
+    column_formatters_detail: ClassVar[Dict[MODEL_ATTR, Callable[..., Any]]] = {}
     """Dictionary of details view column formatters.
     Columns can either be string names or SQLAlchemy columns.
 
@@ -417,9 +417,10 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
     The format function has the prototype:
     ???+ formatter
         ```python
-        def formatter(model, attribute):
+        def formatter(model, attribute, request):
             # `model` is model instance
             # `attribute` is a Union[ColumnProperty, RelationshipProperty]
+            # `request` is a starlette.requests.Request
             pass
         ```
     """
@@ -833,6 +834,36 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
 
         return value
 
+    def _formatter_accepts_request(self, formatter: Callable[..., Any]) -> bool:
+        try:
+            parameters = inspect_module.signature(formatter).parameters.values()
+        except (TypeError, ValueError):
+            return False
+
+        positional_count = 0
+        for parameter in parameters:
+            if parameter.kind == inspect_module.Parameter.VAR_POSITIONAL:
+                return True
+            if parameter.kind in {
+                inspect_module.Parameter.POSITIONAL_ONLY,
+                inspect_module.Parameter.POSITIONAL_OR_KEYWORD,
+            }:
+                positional_count += 1
+
+        return positional_count >= 3
+
+    def _call_formatter(
+        self,
+        formatter: Callable[..., Any],
+        obj: Any,
+        prop: str,
+        request: Request | None = None,
+    ) -> Any:
+        if request is not None and self._formatter_accepts_request(formatter):
+            return formatter(obj, prop, request)
+
+        return formatter(obj, prop)
+
     def validate_page_number(self, number: Union[str, None], default: int) -> int:
         if not number:
             return default
@@ -962,23 +993,31 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
                 session.add(obj)
                 return await anyio.to_thread.run_sync(lambda: getattr(obj, prop))
 
-    async def get_list_value(self, obj: Any, prop: str) -> Tuple[Any, Any]:
+    async def get_list_value(
+        self, obj: Any, prop: str, request: Request | None = None
+    ) -> Tuple[Any, Any]:
         """Get tuple of (value, formatted_value) for the list view."""
 
         value = await self.get_prop_value(obj, prop)
         formatter = self._list_formatters.get(prop)
         formatted_value = (
-            formatter(obj, prop) if formatter else self._default_formatter(value)
+            self._call_formatter(formatter, obj, prop, request)
+            if formatter
+            else self._default_formatter(value)
         )
         return value, formatted_value
 
-    async def get_detail_value(self, obj: Any, prop: str) -> Tuple[Any, Any]:
+    async def get_detail_value(
+        self, obj: Any, prop: str, request: Request | None = None
+    ) -> Tuple[Any, Any]:
         """Get tuple of (value, formatted_value) for the detail view."""
 
         value = await self.get_prop_value(obj, prop)
         formatter = self._detail_formatters.get(prop)
         formatted_value = (
-            formatter(obj, prop) if formatter else self._default_formatter(value)
+            self._call_formatter(formatter, obj, prop, request)
+            if formatter
+            else self._default_formatter(value)
         )
         return value, formatted_value
 

--- a/sqladmin/pretty_export.py
+++ b/sqladmin/pretty_export.py
@@ -5,6 +5,8 @@ from starlette.responses import StreamingResponse
 from sqladmin.helpers import Writer, secure_filename, stream_to_csv
 
 if TYPE_CHECKING:
+    from starlette.requests import Request
+
     from .models import ModelView
 
 
@@ -35,11 +37,15 @@ class PrettyExport:
 
     @classmethod
     async def _get_export_row_values(
-        cls, model_view: "ModelView", row: Any, column_names: List[str]
+        cls,
+        model_view: "ModelView",
+        row: Any,
+        column_names: List[str],
+        request: "Request | None" = None,
     ) -> List[Any]:
         row_values = []
         for name in column_names:
-            value, formatted_value = await model_view.get_list_value(row, name)
+            value, formatted_value = await model_view.get_list_value(row, name, request)
             custom_value = await model_view.custom_export_cell(row, name, value)
             if custom_value is None:
                 cell_value = await cls._base_export_cell(
@@ -52,7 +58,10 @@ class PrettyExport:
 
     @classmethod
     async def pretty_export_csv(
-        cls, model_view: "ModelView", rows: List[Any]
+        cls,
+        model_view: "ModelView",
+        rows: List[Any],
+        request: "Request | None" = None,
     ) -> StreamingResponse:
         async def generate(writer: Writer) -> AsyncGenerator[Any, None]:
             column_names = model_view.get_export_columns()
@@ -63,7 +72,9 @@ class PrettyExport:
             yield writer.writerow(headers)
 
             for row in rows:
-                vals = await cls._get_export_row_values(model_view, row, column_names)
+                vals = await cls._get_export_row_values(
+                    model_view, row, column_names, request
+                )
                 yield writer.writerow(vals)
 
         filename = secure_filename(model_view.get_export_name(export_type="csv"))

--- a/sqladmin/templates/sqladmin/details.html
+++ b/sqladmin/templates/sqladmin/details.html
@@ -24,7 +24,7 @@
             {% set label = model_view._column_labels.get(name, name) %}
             <tr>
               <td>{{ label }}</td>
-              {% set value, formatted_value = model_view.get_detail_value(model, name) %}
+              {% set value, formatted_value = model_view.get_detail_value(model, name, request) %}
               {% if name in model_view._relation_names %}
               {% if is_list( value ) %}
               <td>

--- a/sqladmin/templates/sqladmin/list.html
+++ b/sqladmin/templates/sqladmin/list.html
@@ -159,7 +159,7 @@
                       {% endif %}
                     </td>
                     {% for name in model_view._list_prop_names %}
-                    {% set value, formatted_value = model_view.get_list_value(row, name) %}
+                    {% set value, formatted_value = model_view.get_list_value(row, name, request) %}
                     {% if name in model_view._relation_names %}
                     {% if is_list( value ) %}
                     <td>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -246,6 +246,34 @@ async def test_column_list_formatter_can_receive_request() -> None:
     )
 
 
+async def test_column_list_formatter_request_support_is_cached() -> None:
+    request = Request(
+        {
+            "type": "http",
+            "path": "/admin/user/list",
+            "headers": [(b"host", b"testserver")],
+        }
+    )
+
+    class UserAdmin(ModelView, model=User):
+        column_formatters = {
+            User.name: lambda m, a, r: f"{r.url.path}:{m.name[:1]}",
+        }
+
+    model_view = UserAdmin()
+    user = User(id=1, name="Long Name")
+
+    def fail_if_called(formatter):
+        raise AssertionError("formatter request support should be cached")
+
+    model_view._formatter_accepts_request = fail_if_called
+
+    assert await model_view.get_list_value(user, "name", request) == (
+        "Long Name",
+        "/admin/user/list:L",
+    )
+
+
 async def test_column_formatters_detail() -> None:
     class UserAdmin(ModelView, model=User):
         column_formatters_detail = {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -224,6 +224,28 @@ async def test_column_list_formatters() -> None:
     assert await UserAdmin().get_list_value(user, "name") == ("Long Name", "L")
 
 
+async def test_column_list_formatter_can_receive_request() -> None:
+    request = Request(
+        {
+            "type": "http",
+            "path": "/admin/user/list",
+            "headers": [(b"host", b"testserver")],
+        }
+    )
+
+    class UserAdmin(ModelView, model=User):
+        column_formatters = {
+            User.name: lambda m, a, r: f"{r.url.path}:{m.name[:1]}",
+        }
+
+    user = User(id=1, name="Long Name")
+
+    assert await UserAdmin().get_list_value(user, "name", request) == (
+        "Long Name",
+        "/admin/user/list:L",
+    )
+
+
 async def test_column_formatters_detail() -> None:
     class UserAdmin(ModelView, model=User):
         column_formatters_detail = {
@@ -235,6 +257,28 @@ async def test_column_formatters_detail() -> None:
 
     assert await UserAdmin().get_detail_value(user, "id") == (1, 2)
     assert await UserAdmin().get_detail_value(user, "name") == ("Long Name", "L")
+
+
+async def test_column_detail_formatter_can_receive_request() -> None:
+    request = Request(
+        {
+            "type": "http",
+            "path": "/admin/user/details/1",
+            "headers": [(b"host", b"testserver")],
+        }
+    )
+
+    class UserAdmin(ModelView, model=User):
+        column_formatters_detail = {
+            User.name: lambda m, a, r: f"{r.url.path}:{m.name[:1]}",
+        }
+
+    user = User(id=1, name="Long Name")
+
+    assert await UserAdmin().get_detail_value(user, "name", request) == (
+        "Long Name",
+        "/admin/user/details/1:L",
+    )
 
 
 async def test_column_formatters_default() -> None:

--- a/tests/test_views/test_view_sync.py
+++ b/tests/test_views/test_view_sync.py
@@ -991,6 +991,52 @@ def test_sort_and_search_together_no_ambigious_column_error() -> None:
     assert response.status_code == 200
 
 
+def test_list_column_formatter_receives_request_from_template() -> None:
+    class UserRequestFormatterAdmin(ModelView, model=User):
+        column_list = [User.name]
+        column_formatters = {
+            User.name: lambda m, a, r: str(r.url_for("admin:list", identity="user")),
+        }
+
+    local_app = Starlette()
+    local_admin = Admin(app=local_app, engine=engine)
+    local_admin.add_view(UserRequestFormatterAdmin)
+
+    with session_maker() as session:
+        session.add(User(name="Daniel"))
+        session.commit()
+
+    with TestClient(app=local_app, base_url="http://testserver") as client:
+        response = client.get("/admin/user/list")
+
+    assert response.status_code == 200
+    assert "http://testserver/admin/user/list" in response.text
+
+
+def test_detail_column_formatter_receives_request_from_template() -> None:
+    class UserRequestFormatterAdmin(ModelView, model=User):
+        column_details_list = [User.name]
+        column_formatters_detail = {
+            User.name: lambda m, a, r: str(
+                r.url_for("admin:details", identity="user", pk=m.id)
+            ),
+        }
+
+    local_app = Starlette()
+    local_admin = Admin(app=local_app, engine=engine)
+    local_admin.add_view(UserRequestFormatterAdmin)
+
+    with session_maker() as session:
+        session.add(User(name="Daniel"))
+        session.commit()
+
+    with TestClient(app=local_app, base_url="http://testserver") as client:
+        response = client.get("/admin/user/details/1")
+
+    assert response.status_code == 200
+    assert "http://testserver/admin/user/details/1" in response.text
+
+
 def test_hybrid_property(client: TestClient) -> None:
     with session_maker() as session:
         person = Person(name="Daniel")

--- a/tests/test_views/test_view_sync.py
+++ b/tests/test_views/test_view_sync.py
@@ -870,6 +870,29 @@ def test_export_csv(client: TestClient) -> None:
     assert response.text == "name,status\r\nDaniel,ACTIVE\r\n"
 
 
+def test_pretty_export_csv_formatter_receives_request() -> None:
+    class UserRequestExportAdmin(ModelView, model=User):
+        column_export_list = [User.name]
+        column_formatters = {
+            User.name: lambda m, a, r: str(r.url_for("admin:list", identity="user")),
+        }
+        use_pretty_export = True
+
+    local_app = Starlette()
+    local_admin = Admin(app=local_app, engine=engine)
+    local_admin.add_view(UserRequestExportAdmin)
+
+    with session_maker() as session:
+        user = User(name="Daniel", status="ACTIVE")
+        session.add(user)
+        session.commit()
+
+    with TestClient(app=local_app, base_url="http://testserver") as client:
+        response = client.get("/admin/user/export/csv")
+
+    assert response.text == "name\r\nhttp://testserver/admin/user/list\r\n"
+
+
 def test_export_csv_utf8(client: TestClient) -> None:
     with session_maker() as session:
         user_1 = User(name="Daniel", status="ACTIVE")


### PR DESCRIPTION
Summary
Add request-aware column formatters for list and detail views.
Column formatters can now optionally accept the current Starlette Request as a third argument. This lets formatters build URLs with request.url_for(...) while keeping existing two-argument formatters working unchanged.
Fixes #1015
What Changed
pass request into list and detail formatter rendering paths
support both (model, attribute) and (model, attribute, request) formatter signatures
keep existing formatter behavior for old call sites and two-argument formatters
document the optional request-aware formatter signature
add unit and rendered-page regression coverage for request-aware list/detail formatters
Validation
.venv\Scripts\python.exe -m pytest -q
.venv\Scripts\python.exe -m ruff check sqladmin tests docs
.venv\Scripts\python.exe -m ruff format --check sqladmin tests docs
.venv\Scripts\python.exe -m mypy sqladmin