### PR TITLE
Fix typos in docstrings and documentation

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -376,7 +376,7 @@ The forms are based on `WTForms` package and include the following options:
 
 ### Related models
 
-To define how related model is displayed in the dropdown, `__str__` method must be difined in the related model.
+To define how related model is displayed in the dropdown, `__str__` method must be defined in the related model.
 
 ## Export options
 

--- a/docs/cookbook/display_custom_attributes.md
+++ b/docs/cookbook/display_custom_attributes.md
@@ -1,5 +1,5 @@
 If you need to display a custom attribute of your model,
-or a calculated attribute or property which is not direclty from the database,
+or a calculated attribute or property which is not directly from the database,
 it is possible out of the box with `SQLAdmin`.
 
 Let's see an example model:

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -933,8 +933,8 @@ def action(
         label: Human-readable text describing action
         confirmation_message: Message to show before confirming action
         include_in_schema: Indicating if the endpoint be included in the schema
-        add_in_detail: Indicating if action should be dispalyed on model detail page
-        add_in_list: Indicating if action should be dispalyed on model list page
+        add_in_detail: Indicating if action should be displayed on model detail page
+        add_in_list: Indicating if action should be displayed on model list page
     """
 
     @no_type_check

--- a/sqladmin/fields.py
+++ b/sqladmin/fields.py
@@ -55,7 +55,7 @@ class IntervalField(fields.StringField):
 
         interval = parse_interval(valuelist[0])
         if not interval:
-            raise ValueError("Invalide timedelta format.")
+            raise ValueError("Invalid timedelta format.")
 
         self.data = interval  # type: ignore[assignment]
 


### PR DESCRIPTION
Fix four genuine spelling mistakes found across docstrings and docs:

- `dispalyed` -> `displayed` in `sqladmin/application.py` (`action` decorator docstring, x2)
- `Invalide` -> `Invalid` in `sqladmin/fields.py` (error message string)
- `direclty` -> `directly` in `docs/cookbook/display_custom_attributes.md`
- `difined` -> `defined` in `docs/configurations.md`

All changes are in source code docstrings and documentation prose — no fixture data, generated files, or identifiers were touched.