### PR TITLE
added keywords arguments for self.templates.TemplateResponse

### DIFF
--- a/docs/cookbook/displaying_one_time_secrets.md
+++ b/docs/cookbook/displaying_one_time_secrets.md
@@ -43,7 +43,7 @@ built-in create/edit handlers stamp anti-cache headers on the response
 automatically; custom views must do so explicitly:
 
 ```python
-response = await self.templates.TemplateResponse(request, "your_template.html", context)
+response = await self.templates.TemplateResponse(request=request, name="your_template.html", context=context)
 Secret.apply_no_store_headers(response)
 return response
 ```

--- a/docs/writing_custom_views.md
+++ b/docs/writing_custom_views.md
@@ -15,7 +15,7 @@ To add custom views to the Admin interface, you can use the `BaseView` included 
 
         @expose("/report", methods=["GET"])
         async def report_page(self, request):
-            return await self.templates.TemplateResponse(request, "report.html")
+            return await self.templates.TemplateResponse(request=request, name="report.html")
 
     admin.add_view(ReportView)
     ```

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -283,7 +283,7 @@ class BaseAdmin:
 
                 @expose("/custom", methods=["GET"])
                 async def test_page(self, request: Request):
-                    return await self.templates.TemplateResponse(request, "custom.html")
+                    return await self.templates.TemplateResponse(request=request, name="custom.html")
 
             admin.add_base_view(CustomAdmin)
             ```
@@ -508,7 +508,7 @@ class Admin(BaseAdminView):
                 "message": exc.detail,
             }
             return await self.templates.TemplateResponse(
-                request, "sqladmin/error.html", context, status_code=exc.status_code
+                request=request, name="sqladmin/error.html", context=context, status_code=exc.status_code
             )
 
         routes = [
@@ -573,7 +573,7 @@ class Admin(BaseAdminView):
     async def index(self, request: Request) -> Response:
         """Index route which can be overridden to create dashboards."""
 
-        return await self.templates.TemplateResponse(request, "sqladmin/index.html")
+        return await self.templates.TemplateResponse(request=request, name="sqladmin/index.html")
 
     @login_required
     async def list(self, request: Request) -> Response:
@@ -604,7 +604,7 @@ class Admin(BaseAdminView):
             context["error"] = request.query_params["error"]
 
         return await self.templates.TemplateResponse(
-            request, model_view.list_template, context
+            request=request, name=model_view.list_template, context=context
         )
 
     @login_required
@@ -625,7 +625,7 @@ class Admin(BaseAdminView):
         }
 
         return await self.templates.TemplateResponse(
-            request, model_view.details_template, context
+            request=request, name=model_view.details_template, context=context
         )
 
     @login_required
@@ -678,7 +678,7 @@ class Admin(BaseAdminView):
             context["secret_next_url"] = str(
                 request.url_for("admin:list", identity=identity)
             )
-            response = await self.templates.TemplateResponse(request, template, context)
+            response = await self.templates.TemplateResponse(request=request, name=template, context=context)
             Secret.apply_no_store_headers(response)
             return response
 
@@ -701,7 +701,7 @@ class Admin(BaseAdminView):
                 "form": form,
             }
             return await self.templates.TemplateResponse(
-                request, model_view.create_template, context
+                request=request, name=model_view.create_template, context=context
             )
 
         form_data = await self._handle_form_data(request)
@@ -714,7 +714,7 @@ class Admin(BaseAdminView):
 
         if not form.validate():
             return await self.templates.TemplateResponse(
-                request, model_view.create_template, context, status_code=400
+                request=request, name=model_view.create_template, context=context, status_code=400
             )
 
         form_data_dict = self._denormalize_wtform_data(form.data, model_view.model)
@@ -724,7 +724,7 @@ class Admin(BaseAdminView):
             logger.exception(e)
             context["error"] = str(e)
             return await self.templates.TemplateResponse(
-                request, model_view.create_template, context, status_code=400
+                request=request, name=model_view.create_template, context=context, status_code=400
             )
 
         override = await self._resolve_after_change_response(
@@ -763,7 +763,7 @@ class Admin(BaseAdminView):
 
         if request.method == "GET":
             return await self.templates.TemplateResponse(
-                request, model_view.edit_template, context
+                request=request, name=model_view.edit_template, context=context
             )
 
         form_data = await self._handle_form_data(request, model)
@@ -772,7 +772,7 @@ class Admin(BaseAdminView):
 
         if not form.validate():
             return await self.templates.TemplateResponse(
-                request, model_view.edit_template, context, status_code=400
+                request=request, name=model_view.edit_template, context=context, status_code=400
             )
 
         form_data_dict = self._denormalize_wtform_data(form.data, model)
@@ -787,7 +787,7 @@ class Admin(BaseAdminView):
             logger.exception(e)
             context["error"] = str(e)
             return await self.templates.TemplateResponse(
-                request, model_view.edit_template, context, status_code=400
+                request=request, name=model_view.edit_template, context=context, status_code=400
             )
 
         override = await self._resolve_after_change_response(
@@ -855,13 +855,13 @@ class Admin(BaseAdminView):
 
         context = {}
         if request.method == "GET":
-            return await self.templates.TemplateResponse(request, "sqladmin/login.html")
+            return await self.templates.TemplateResponse(request=request, name="sqladmin/login.html")
 
         response = await self.authentication_backend.login(request)
         if not response:
             context["error"] = "Invalid credentials."
             return await self.templates.TemplateResponse(
-                request, "sqladmin/login.html", context, status_code=400
+                request=request, name="sqladmin/login.html", context=context, status_code=400
             )
 
         if isinstance(response, Response):

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -283,7 +283,8 @@ class BaseAdmin:
 
                 @expose("/custom", methods=["GET"])
                 async def test_page(self, request: Request):
-                    return await self.templates.TemplateResponse(request=request, name="custom.html")
+                    return await self.templates.TemplateResponse(
+                    request=request, name="custom.html")
 
             admin.add_base_view(CustomAdmin)
             ```
@@ -508,7 +509,10 @@ class Admin(BaseAdminView):
                 "message": exc.detail,
             }
             return await self.templates.TemplateResponse(
-                request=request, name="sqladmin/error.html", context=context, status_code=exc.status_code
+                request=request,
+                name="sqladmin/error.html",
+                context=context,
+                status_code=exc.status_code,
             )
 
         routes = [
@@ -573,7 +577,9 @@ class Admin(BaseAdminView):
     async def index(self, request: Request) -> Response:
         """Index route which can be overridden to create dashboards."""
 
-        return await self.templates.TemplateResponse(request=request, name="sqladmin/index.html")
+        return await self.templates.TemplateResponse(
+            request=request, name="sqladmin/index.html"
+        )
 
     @login_required
     async def list(self, request: Request) -> Response:
@@ -678,7 +684,9 @@ class Admin(BaseAdminView):
             context["secret_next_url"] = str(
                 request.url_for("admin:list", identity=identity)
             )
-            response = await self.templates.TemplateResponse(request=request, name=template, context=context)
+            response = await self.templates.TemplateResponse(
+                request=request, name=template, context=context
+            )
             Secret.apply_no_store_headers(response)
             return response
 
@@ -714,7 +722,10 @@ class Admin(BaseAdminView):
 
         if not form.validate():
             return await self.templates.TemplateResponse(
-                request=request, name=model_view.create_template, context=context, status_code=400
+                request=request,
+                name=model_view.create_template,
+                context=context,
+                status_code=400,
             )
 
         form_data_dict = self._denormalize_wtform_data(form.data, model_view.model)
@@ -724,7 +735,10 @@ class Admin(BaseAdminView):
             logger.exception(e)
             context["error"] = str(e)
             return await self.templates.TemplateResponse(
-                request=request, name=model_view.create_template, context=context, status_code=400
+                request=request,
+                name=model_view.create_template,
+                context=context,
+                status_code=400,
             )
 
         override = await self._resolve_after_change_response(
@@ -772,7 +786,10 @@ class Admin(BaseAdminView):
 
         if not form.validate():
             return await self.templates.TemplateResponse(
-                request=request, name=model_view.edit_template, context=context, status_code=400
+                request=request,
+                name=model_view.edit_template,
+                context=context,
+                status_code=400,
             )
 
         form_data_dict = self._denormalize_wtform_data(form.data, model)
@@ -787,7 +804,10 @@ class Admin(BaseAdminView):
             logger.exception(e)
             context["error"] = str(e)
             return await self.templates.TemplateResponse(
-                request=request, name=model_view.edit_template, context=context, status_code=400
+                request=request,
+                name=model_view.edit_template,
+                context=context,
+                status_code=400,
             )
 
         override = await self._resolve_after_change_response(
@@ -855,13 +875,18 @@ class Admin(BaseAdminView):
 
         context = {}
         if request.method == "GET":
-            return await self.templates.TemplateResponse(request=request, name="sqladmin/login.html")
+            return await self.templates.TemplateResponse(
+                request=request, name="sqladmin/login.html"
+            )
 
         response = await self.authentication_backend.login(request)
         if not response:
             context["error"] = "Invalid credentials."
             return await self.templates.TemplateResponse(
-                request=request, name="sqladmin/login.html", context=context, status_code=400
+                request=request,
+                name="sqladmin/login.html",
+                context=context,
+                status_code=400,
             )
 
         if isinstance(response, Response):

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -169,7 +169,7 @@ class BaseView(BaseModelView):
 
             @expose("/custom", methods=["GET"])
             async def test_page(self, request: Request):
-                return await self.templates.TemplateResponse(request, "custom.html")
+                return await self.templates.TemplateResponse(request=request, name="custom.html")
 
         admin.add_base_view(CustomAdmin)
         ```

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -169,7 +169,8 @@ class BaseView(BaseModelView):
 
             @expose("/custom", methods=["GET"])
             async def test_page(self, request: Request):
-                return await self.templates.TemplateResponse(request=request, name="custom.html")
+                return await self.templates.TemplateResponse(
+                request=request, name="custom.html")
 
         admin.add_base_view(CustomAdmin)
         ```

--- a/tests/test_base_view.py
+++ b/tests/test_base_view.py
@@ -21,17 +21,17 @@ class CustomAdmin(BaseView):
 
     @expose("/custom", methods=["GET"])
     async def custom(self, request: Request):
-        return await self.templates.TemplateResponse(request, "custom.html")
+        return await self.templates.TemplateResponse(request=request, name="custom.html")
 
     @expose("/custom/report")
     async def custom_report(self, request: Request):
-        return await self.templates.TemplateResponse(request, "custom.html")
+        return await self.templates.TemplateResponse(request=request, name="custom.html")
 
     # Add this for second test: Before alphabetically (!)
     # first `expose` was BaseView url, now it's first by `order`
     @expose("/a")
     async def a(self, request: Request):
-        return await self.templates.TemplateResponse(request, "custom.html")
+        return await self.templates.TemplateResponse(request=request, name="custom.html")
 
 
 @pytest.fixture
@@ -69,7 +69,7 @@ class IndexNamedView(BaseView):
 
     @expose("/activity-analytics", methods=["GET"])
     async def index(self, request: Request):
-        return await self.templates.TemplateResponse(request, "custom.html")
+        return await self.templates.TemplateResponse(request=request, name="custom.html")
 
 
 def test_menu_view_url_with_index_method(client: TestClient) -> None:

--- a/tests/test_base_view.py
+++ b/tests/test_base_view.py
@@ -21,17 +21,23 @@ class CustomAdmin(BaseView):
 
     @expose("/custom", methods=["GET"])
     async def custom(self, request: Request):
-        return await self.templates.TemplateResponse(request=request, name="custom.html")
+        return await self.templates.TemplateResponse(
+            request=request, name="custom.html"
+        )
 
     @expose("/custom/report")
     async def custom_report(self, request: Request):
-        return await self.templates.TemplateResponse(request=request, name="custom.html")
+        return await self.templates.TemplateResponse(
+            request=request, name="custom.html"
+        )
 
     # Add this for second test: Before alphabetically (!)
     # first `expose` was BaseView url, now it's first by `order`
     @expose("/a")
     async def a(self, request: Request):
-        return await self.templates.TemplateResponse(request=request, name="custom.html")
+        return await self.templates.TemplateResponse(
+            request=request, name="custom.html"
+        )
 
 
 @pytest.fixture
@@ -69,7 +75,9 @@ class IndexNamedView(BaseView):
 
     @expose("/activity-analytics", methods=["GET"])
     async def index(self, request: Request):
-        return await self.templates.TemplateResponse(request=request, name="custom.html")
+        return await self.templates.TemplateResponse(
+            request=request, name="custom.html"
+        )
 
 
 def test_menu_view_url_with_index_method(client: TestClient) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -860,7 +860,7 @@ def test_expose_decorator(client: TestClient) -> None:
         async def profile(self, request: Request):
             user: User = await self.get_object_for_edit(request)
             return await self.templates.TemplateResponse(
-                request, "user.html", {"user": user}
+                request=request, name="user.html", context={"user": user}
             )
 
     admin.add_view(UserAdmin)


### PR DESCRIPTION
Update here https://fastapi.tiangolo.com/advanced/templates/ now templateResponse demands use

this structure

```
templates.TemplateResponse(
        request=request, name="item.html", context={"id": id}
    )
```

previously was

```
templates.TemplateResponse(
       request, "item.html",{"id": id}
    )
```