### PR TITLE
fix: unwrap Enum values in get_object_identifier

### DIFF
--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -298,6 +298,7 @@ def get_object_identifier(obj: Any) -> Any:
     """Returns a value that uniquely identifies this object."""
     primary_keys = get_primary_keys(obj)
     values = [getattr(obj, pk.name) for pk in primary_keys]
+    values = [v.value if isinstance(v, enum.Enum) else v for v in values]
 
     # Unaltered value for tables with a single primary key
     if len(values) == 1:

--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -294,11 +294,24 @@ def get_primary_keys(model: Any) -> tuple[Column, ...]:
     return tuple(sa_inspect(model).mapper.primary_key)
 
 
+def _coerce_pk_value(value: Any) -> Any:
+    """Unwrap an Enum primary key to its underlying value.
+
+    SQLAlchemy returns the Enum member itself (e.g. ``Color.RED``) for a
+    column typed as an Enum, not its underlying value (e.g. ``"red"``).
+    Object identifiers are embedded in admin URLs, so the raw member's
+    ``str()`` (``"Color.RED"``) would produce a broken, non-round-trippable
+    path. Non-Enum values pass through unchanged.
+    """
+    if isinstance(value, enum.Enum):
+        return value.value
+    return value
+
+
 def get_object_identifier(obj: Any) -> Any:
     """Returns a value that uniquely identifies this object."""
     primary_keys = get_primary_keys(obj)
-    values = [getattr(obj, pk.name) for pk in primary_keys]
-    values = [v.value if isinstance(v, enum.Enum) else v for v in values]
+    values = [_coerce_pk_value(getattr(obj, pk.name)) for pk in primary_keys]
 
     # Unaltered value for tables with a single primary key
     if len(values) == 1:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+import enum
 import uuid
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Annotated, Any
@@ -9,6 +10,7 @@ from sqlalchemy import (
     Column,
     Date,
     DateTime,
+    Enum,
     ForeignKey,
     Integer,
     String,
@@ -93,6 +95,16 @@ class Flagged(Base):
     __tablename__ = "flagged"
     id = Column(Integer, primary_key=True)
     active = Column(Boolean, nullable=False)
+
+
+class AnimalEnum(str, enum.Enum):
+    DOG = "dog"
+    CAT = "cat"
+
+
+class Animal(Base):
+    __tablename__ = "animal"
+    id = Column(Enum(AnimalEnum), primary_key=True)
 
 
 def test_coerce_column_value() -> None:
@@ -234,6 +246,12 @@ def test_single_pk_identifier():
 
     assert get_object_identifier(Profile(id=0)) == 0
     assert get_object_identifier(Profile(id=3217)) == 3217
+
+
+def test_single_pk_identifier_with_enum():
+    identifier = get_object_identifier(Animal(id=AnimalEnum.DOG))
+    assert identifier == "dog"
+    assert isinstance(identifier, str)
 
 
 def test_single_pk_id_values():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -251,7 +251,11 @@ def test_single_pk_identifier():
 def test_single_pk_identifier_with_enum():
     identifier = get_object_identifier(Animal(id=AnimalEnum.DOG))
     assert identifier == "dog"
-    assert isinstance(identifier, str)
+    # `AnimalEnum` subclasses `str`, so an unwrapped enum member already
+    # equals and isinstance-checks as "dog" even without the fix in
+    # `get_object_identifier` -- assert the exact type to actually catch
+    # a regression back to returning the raw enum member.
+    assert type(identifier) is str
 
 
 def test_single_pk_id_values():


### PR DESCRIPTION
## Summary

`get_object_identifier()` returns the raw primary key value(s) for use in URLs and ajax lookups. For models whose primary key is an `Enum` column, it was returning the Enum member itself rather than its value, so `str()` on it produced `AnimalEnum.DOG` instead of `dog`. This broke generated edit/detail URLs for such models (e.g. `/admin/animal/edit/AnimalEnum.DOG`).

This unwraps Enum members to their `.value` before use, for both single and composite primary keys.

Closes #955

## Test plan

- Added `test_single_pk_identifier_with_enum` in `tests/test_helpers.py`, covering a model with an `Enum` primary key.
- `uv run pytest --cov=sqladmin --cov-report=term-missing` — 484 passed, 4 skipped (pre-existing), coverage 97.10%.
- `make lint` (ruff check, ruff format --check, mypy) — all pass.