### PR TITLE
fix: mark custom (BaseView) menu items active on their own page (#956)

### DIFF
--- a/sqladmin/_menu.py
+++ b/sqladmin/_menu.py
@@ -69,7 +69,14 @@ class ViewMenu(ItemMenu):
         return self.view.is_accessible(request)
 
     def is_active(self, request: Request) -> bool:
-        return self.view.identity == request.path_params.get("identity")
+        if self.view.is_model:
+            return self.view.identity == request.path_params.get("identity")
+        # Custom (BaseView) views are served from a fixed path that has no
+        # ``identity`` path parameter, so ``request.path_params`` never carries
+        # one and the identity comparison would always fail (see #956). Match on
+        # the resolved URL path instead.
+        view_path = URL(str(self.url(request))).path.rstrip("/")
+        return request.url.path.rstrip("/") == view_path
 
     def url(self, request: Request) -> str | URL:
         if self.view.is_model:

--- a/tests/test_base_view.py
+++ b/tests/test_base_view.py
@@ -63,6 +63,28 @@ def test_menu_view_url(client: TestClient) -> None:
     )
 
 
+def test_menu_active_on_custom_view(client: TestClient) -> None:
+    # Regression test for #956: custom (BaseView) menu items were never marked
+    # active, because is_active compared the view identity against an `identity`
+    # path param that custom-view routes do not have.
+    admin.add_view(CustomAdmin)
+
+    # On the custom view's own page the sidebar link is marked active.
+    response = client.get("/admin/custom")
+    assert response.status_code == 200
+    assert (
+        '<a class="nav-link active" href="http://testserver/admin/custom">'
+        in response.text
+    )
+
+    # On an unrelated page (the admin index) it is not active.
+    response = client.get("/admin")
+    assert response.status_code == 200
+    assert (
+        '<a class="nav-link " href="http://testserver/admin/custom">' in response.text
+    )
+
+
 class IndexNamedView(BaseView):
     name = "Activity Analytics"
     icon = "fa fa-chart"


### PR DESCRIPTION
Closes #956 