### PR TITLE
feat: add per-page template context hooks (#942)

### DIFF
--- a/docs/working_with_templates.md
+++ b/docs/working_with_templates.md
@@ -26,6 +26,37 @@ SQLAdmin and in the `content` block it adds custom HTML tags:
         details_template = "sqladmin/custom_details.html"
     ```
 
+### Passing extra context to templates
+
+Each model view page can pass extra values to its template through a per-page
+context hook. Override any of `list_context`, `create_context`, `edit_context`
+or `details_context` on your `ModelView` to return a mapping that is merged into
+the template context for that page. Every hook is `async`, receives the
+`request`, and returns `{}` by default:
+
+!!! example
+
+    ```python title="admin.py"
+    class UserAdmin(ModelView, model=User):
+        details_template = "sqladmin/custom_details.html"
+
+        async def details_context(self, request: Request) -> dict:
+            return {"extra_note": "Read-only for auditors"}
+    ```
+
+    ```html title="custom_details.html"
+    {% extends "sqladmin/details.html" %}
+    {% block content %}
+        {{ super() }}
+        <p>{{ extra_note }}</p>
+    {% endblock %}
+    ```
+
+The returned values are added to the context already passed to the page, so they
+are available as top-level variables in the template. The core context keys that
+SQLAdmin sets (such as `model_view`, `form`, `pagination` and `model`) always
+take precedence, so a hook can add new values but cannot override them.
+
 ### Customizing column filter templates
 
 Each built-in column filter declares a `template` attribute which defaults to one of

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -647,6 +647,7 @@ class Admin(BaseAdminView):
             )
 
         context = {
+            **await model_view.list_context(request),
             "model_view": model_view,
             "pagination": pagination,
             "can_import": await model_view.check_can_import(request),
@@ -671,6 +672,7 @@ class Admin(BaseAdminView):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
         context = {
+            **await model_view.details_context(request),
             "model_view": model_view,
             "model": model,
             "title": model_view.name,
@@ -748,9 +750,12 @@ class Admin(BaseAdminView):
 
         Form = await model_view.scaffold_form(model_view._form_create_rules)
 
+        create_context = await model_view.create_context(request)
+
         if request.method == "GET":
             form = Form()
             context = {
+                **create_context,
                 "model_view": model_view,
                 "form": form,
             }
@@ -762,6 +767,7 @@ class Admin(BaseAdminView):
         form = Form(form_data)
 
         context = {
+            **create_context,
             "model_view": model_view,
             "form": form,
         }
@@ -816,6 +822,7 @@ class Admin(BaseAdminView):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         initial_data = await model_view.get_form_data_for_edit(model)
         context = {
+            **await model_view.edit_context(request),
             "obj": model,
             "model_view": model_view,
             "form": Form(data=initial_data),

--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -1374,6 +1374,27 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
         * ``Response`` -- return a custom Starlette ``Response`` directly.
         """
 
+    async def list_context(self, request: Request) -> dict[str, Any]:
+        """Extra template context for the list page.
+
+        Return a mapping that is merged into the base context for the list
+        template. Returns ``{}`` by default. Core keys (``model_view``,
+        ``pagination``, ...) always take precedence, so this can only add keys.
+        """
+        return {}
+
+    async def create_context(self, request: Request) -> dict[str, Any]:
+        """Extra template context for the create page. See :meth:`list_context`."""
+        return {}
+
+    async def edit_context(self, request: Request) -> dict[str, Any]:
+        """Extra template context for the edit page. See :meth:`list_context`."""
+        return {}
+
+    async def details_context(self, request: Request) -> dict[str, Any]:
+        """Extra template context for the details page. See :meth:`list_context`."""
+        return {}
+
     def _build_column_pairs(
         self,
         pair: dict[Any, Any],

--- a/tests/templates/context_probe.html
+++ b/tests/templates/context_probe.html
@@ -1,0 +1,1 @@
+{{ probe }}-{{ model_view.name }}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -867,3 +867,67 @@ def test_expose_decorator(client: TestClient) -> None:
 
     with pytest.raises(TemplateNotFound, match="user.html"):
         client.get("/admin/user/profile/1")
+
+
+async def test_page_context_hooks_default_empty() -> None:
+    # #942: each page context hook returns {} by default.
+    class PlainAdmin(ModelView, model=User):
+        pass
+
+    view = PlainAdmin()
+    request = Request({"type": "http"})
+    assert await view.list_context(request) == {}
+    assert await view.create_context(request) == {}
+    assert await view.edit_context(request) == {}
+    assert await view.details_context(request) == {}
+
+
+async def test_page_context_hook_merged_into_template() -> None:
+    # #942: an overridden page context hook is merged into that page's
+    # template context. The create GET page renders without touching the DB.
+    local_app = Starlette()
+    local_admin = Admin(
+        app=local_app,
+        session_maker=session_maker,
+        templates_dir="tests/templates",
+    )
+
+    class ProbeAdmin(ModelView, model=User):
+        create_template = "context_probe.html"
+
+        async def create_context(self, request: Request) -> dict:
+            return {"probe": "PROBE_VALUE"}
+
+    local_admin.add_view(ProbeAdmin)
+
+    with TestClient(local_app) as client:
+        response = client.get("/admin/user/create")
+
+    assert response.status_code == 200
+    assert "PROBE_VALUE" in response.text
+
+
+async def test_page_context_hook_cannot_override_core_keys() -> None:
+    # Core keys (e.g. model_view) always win over hook-provided values.
+    local_app = Starlette()
+    local_admin = Admin(
+        app=local_app,
+        session_maker=session_maker,
+        templates_dir="tests/templates",
+    )
+
+    class ProbeAdmin(ModelView, model=User):
+        create_template = "context_probe.html"
+
+        async def create_context(self, request: Request) -> dict:
+            return {"model_view": "HIJACKED", "probe": "ok"}
+
+    local_admin.add_view(ProbeAdmin)
+
+    with TestClient(local_app) as client:
+        response = client.get("/admin/user/create")
+
+    assert response.status_code == 200
+    # The real model_view survived (its name rendered); the hook value lost.
+    assert "User" in response.text
+    assert "HIJACKED" not in response.text


### PR DESCRIPTION
Closes #942. Add list_context, create_context, edit_context and details_context to ModelView. Each returns {} by default and its result is merged into that page's template context, so a view can supply extra data per page. Core context keys always take precedence, so hooks can only add keys.