### PR TITLE
feat: add JSONEditorField for editing JSON columns (#1025)

### DIFF
--- a/docs/cookbook/using_wysiwyg.md
+++ b/docs/cookbook/using_wysiwyg.md
@@ -59,6 +59,8 @@ class PostAdmin(ModelView, model=Post):
             "api_key": "your-api-key",
             "plugins": "lists link table code",
             "toolbar": "bold italic | link | code",
+            # CSS injected into the editor's editable area
+            "content_style": "body { font-family: Inter; }",
         }
     }
 ```

--- a/docs/cookbook/using_wysiwyg.md
+++ b/docs/cookbook/using_wysiwyg.md
@@ -174,3 +174,24 @@ Use it like any built-in editor:
 class PostAdmin(ModelView, model=Post):
     form_overrides = {"content": MyEditorField}
 ```
+
+
+## Editing JSON columns
+
+For `JSON`/`JSONB` columns, `JSONEditorField` renders the
+[JSONEditor](https://github.com/josdejong/jsoneditor) widget (tree and code
+views) instead of a plain textarea. It uses the same `form_overrides` /
+`form_args` mechanism and loads its assets automatically:
+
+```python
+from sqladmin.editors import JSONEditorField
+
+class ConfigAdmin(ModelView, model=Config):
+    form_overrides = {"data": JSONEditorField}
+    form_args = {"data": {"mode": "code", "version": "10.1.0"}}
+```
+
+`mode` selects the initial editor mode (`"tree"`, `"code"`, `"form"`, `"text"`
+or `"view"`). The stored value is a real JSON value (a dict or list), not a
+string, since `JSONEditorField` builds on the JSON handling of
+`sqladmin.fields.JSONField`.

--- a/sqladmin/editors.py
+++ b/sqladmin/editors.py
@@ -6,6 +6,8 @@ from typing import Any
 from wtforms import Form
 from wtforms.fields import TextAreaField
 
+from sqladmin.fields import JSONField
+
 
 class FieldMedia:
     """
@@ -203,4 +205,46 @@ class SummernoteField(TextAreaField):
                 f"https://cdn.jsdelivr.net/npm/summernote@{self._VERSION}/dist/summernote-bs4.min.css"
             ],
             js=js,
+        )
+
+
+class JSONEditorField(JSONField):
+    """
+    A field rendered with the `JSONEditor <https://github.com/josdejong/jsoneditor>`_
+    widget for editing ``JSON``/``JSONB`` columns.
+
+    Inherits the JSON serialisation of :class:`sqladmin.fields.JSONField`, so
+    the stored value is a real JSON value (dict/list), not a string. Use it
+    through ``form_overrides`` and configure it with ``form_args``::
+
+        class ConfigAdmin(ModelView, model=Config):
+            form_overrides = {"data": JSONEditorField}
+            form_args = {"data": {"mode": "code"}}
+
+    Assets are loaded from a CDN. Pass ``version`` to pin a release and
+    ``mode`` to pick the initial editor mode (one of ``"tree"``, ``"code"``,
+    ``"form"``, ``"text"`` or ``"view"``).
+    """
+
+    editor_init_template = "sqladmin/editors/jsoneditor.html"
+
+    def __init__(
+        self,
+        *args: Any,
+        version: str = "10.1.0",
+        mode: str = "tree",
+        min_height: int = 300,
+        **kwargs: Any,
+    ) -> None:
+        self.version = version
+        self.mode = mode
+        self.min_height = min_height
+        super().__init__(*args, **kwargs)
+
+    @property
+    def media(self) -> FieldMedia:
+        base = f"https://cdn.jsdelivr.net/npm/jsoneditor@{self.version}/dist"
+        return FieldMedia(
+            css=[f"{base}/jsoneditor.min.css"],
+            js=[f"{base}/jsoneditor.min.js"],
         )

--- a/sqladmin/editors.py
+++ b/sqladmin/editors.py
@@ -114,12 +114,14 @@ class TinyMCEField(TextAreaField):
         plugins: str = "lists link table code wordcount",
         toolbar: str = "bold italic | link | code",
         min_height: int = 200,
+        content_style: str = "",
         **kwargs: Any,
     ) -> None:
         self.api_key = api_key
         self.plugins = plugins
         self.toolbar = toolbar
         self.min_height = min_height
+        self.content_style = content_style
         super().__init__(*args, **kwargs)
 
     @property

--- a/sqladmin/templates/sqladmin/editors/jsoneditor.html
+++ b/sqladmin/templates/sqladmin/editors/jsoneditor.html
@@ -1,0 +1,42 @@
+<script>
+  (function () {
+    var fieldId = "{{ field.id }}";
+    var mode = "{{ field.mode }}";
+    var minHeight = {{ field.min_height }};
+
+    var textarea = document.getElementById(fieldId);
+    if (!textarea || textarea.dataset.jsoneditorInitialized === "1") {
+      return;
+    }
+    textarea.dataset.jsoneditorInitialized = "1";
+
+    var container = document.createElement("div");
+    container.style.minHeight = minHeight + "px";
+    textarea.parentNode.insertBefore(container, textarea);
+    textarea.style.display = "none";
+
+    var initial = {};
+    try {
+      initial = textarea.value ? JSON.parse(textarea.value) : {};
+    } catch (e) {
+      initial = {};
+    }
+
+    var editor = new JSONEditor(container, {
+      mode: mode,
+      modes: ["tree", "code", "form", "text", "view"],
+    });
+    editor.set(initial);
+
+    var form = textarea.closest("form");
+    if (form) {
+      form.addEventListener("submit", function () {
+        try {
+          textarea.value = JSON.stringify(editor.get());
+        } catch (e) {
+          /* keep the existing textarea value if the editor content is invalid */
+        }
+      });
+    }
+  })();
+</script>

--- a/sqladmin/templates/sqladmin/editors/tinymce.html
+++ b/sqladmin/templates/sqladmin/editors/tinymce.html
@@ -6,6 +6,7 @@
       plugins: "{{ field.plugins }}",
       toolbar: "{{ field.toolbar }}",
       min_height: {{ field.min_height }},
+      content_style: {{ field.content_style | tojson }},
       promotion: false,
       resize: false,
     });

--- a/tests/test_rich_text_editors.py
+++ b/tests/test_rich_text_editors.py
@@ -432,3 +432,25 @@ def test_edit_page_loads_jsoneditor() -> None:
         response = c.get(f"/admin/config/edit/{config_id}")
     assert response.status_code == 200
     assert "jsoneditor.min.js" in response.text
+
+
+def test_tinymce_field_default_content_style() -> None:
+    field = _bind(TinyMCEField)
+    assert field.content_style == ""
+
+
+def test_tinymce_field_content_style() -> None:
+    field = _bind(TinyMCEField, content_style="body { font-size: 14px; }")
+    assert field.content_style == "body { font-size: 14px; }"
+
+
+def test_create_page_tinymce_content_style() -> None:
+    class PostAdmin(ModelView, model=Post):
+        form_overrides = {"content": TinyMCEField}
+        form_args = {"content": {"content_style": "body { color: red; }"}}
+
+    with _make_client(PostAdmin) as c:
+        response = c.get("/admin/post/create")
+    assert response.status_code == 200
+    assert "content_style" in response.text
+    assert "color: red" in response.text

--- a/tests/test_rich_text_editors.py
+++ b/tests/test_rich_text_editors.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 
 import pytest
-from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy import JSON, Column, Integer, String, Text
 from sqlalchemy.orm import Session, declarative_base
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
@@ -11,6 +11,7 @@ from sqladmin import Admin, ModelView
 from sqladmin.editors import (
     CKEditor5Field,
     FieldMedia,
+    JSONEditorField,
     QuillField,
     SummernoteField,
     TinyMCEField,
@@ -29,6 +30,13 @@ class Post(Base):
     content = Column(Text)
     summary = Column(Text)
     notes = Column(Text)
+
+
+class Config(Base):
+    __tablename__ = "configs_editors"
+
+    id = Column(Integer, primary_key=True)
+    data = Column(JSON)
 
 
 def _make_client(view_class: type[ModelView]) -> TestClient:
@@ -374,3 +382,53 @@ def test_form_args_passed_to_field() -> None:
     with _make_client(PostAdmin) as c:
         response = c.get("/admin/post/create")
     assert "quill.bubble.css" in response.text
+
+
+#  JSONEditorField
+def test_jsoneditor_field_media() -> None:
+    field = _bind(JSONEditorField)
+    assert any("jsoneditor.min.js" in url for url in field.media.js)
+    assert any("jsoneditor.min.css" in url for url in field.media.css)
+
+
+def test_jsoneditor_field_custom_version() -> None:
+    field = _bind(JSONEditorField, version="9.10.0")
+    assert any("jsoneditor@9.10.0" in url for url in field.media.js)
+
+
+def test_jsoneditor_field_default_mode() -> None:
+    field = _bind(JSONEditorField)
+    assert field.mode == "tree"
+
+
+def test_jsoneditor_field_init_template() -> None:
+    field = _bind(JSONEditorField)
+    assert field.editor_init_template == "sqladmin/editors/jsoneditor.html"
+
+
+def test_create_page_loads_jsoneditor() -> None:
+    class ConfigAdmin(ModelView, model=Config):
+        form_overrides = {"data": JSONEditorField}
+
+    with _make_client(ConfigAdmin) as c:
+        response = c.get("/admin/config/create")
+    assert response.status_code == 200
+    assert "jsoneditor.min.js" in response.text
+    assert "jsoneditor.min.css" in response.text
+    assert "new JSONEditor" in response.text
+
+
+def test_edit_page_loads_jsoneditor() -> None:
+    class ConfigAdmin(ModelView, model=Config):
+        form_overrides = {"data": JSONEditorField}
+
+    with Session(engine) as session:
+        config = Config(data={"a": 1})
+        session.add(config)
+        session.commit()
+        config_id = config.id
+
+    with _make_client(ConfigAdmin) as c:
+        response = c.get(f"/admin/config/edit/{config_id}")
+    assert response.status_code == 200
+    assert "jsoneditor.min.js" in response.text


### PR DESCRIPTION
Closes #1025. Add JSONEditorField, a form field that renders the josdejong JSONEditor widget for JSON/JSONB columns. Built on the existing pluggable-editor media infrastructure and JSONField serialisation; opt in via form_overrides / form_args, assets load from CDN. Includes tests and docs.