### PR TITLE
Fix: Making hidden textareas non-required

### DIFF
--- a/sqladmin/editors.py
+++ b/sqladmin/editors.py
@@ -56,7 +56,25 @@ def collect_form_media(form: Form) -> FieldMedia:
     return media
 
 
-class CKEditor5Field(TextAreaField):
+class RichTextFieldMixin:
+    """
+    Shared behaviour for WYSIWYG fields that replace a ``<textarea>``.
+
+    Editors hide the original textarea. If it still has the HTML5 ``required``
+    attribute, Chrome blocks submit with::
+
+        An invalid form control with name='...' is not focusable.
+
+    No request is sent. Keep WTForms server-side required validators; only the
+    client-side attribute is suppressed.
+    """
+
+    def __call__(self, **kwargs: Any) -> Any:
+        kwargs["required"] = False
+        return super().__call__(**kwargs)  # type: ignore[misc]
+
+
+class CKEditor5Field(RichTextFieldMixin, TextAreaField):
     """
     A ``TextAreaField`` rendered with the CKEditor 5 rich text editor.
 
@@ -92,7 +110,7 @@ class CKEditor5Field(TextAreaField):
         )
 
 
-class TinyMCEField(TextAreaField):
+class TinyMCEField(RichTextFieldMixin, TextAreaField):
     """
     A ``TextAreaField`` rendered with the TinyMCE rich text editor.
 
@@ -127,7 +145,7 @@ class TinyMCEField(TextAreaField):
         )
 
 
-class QuillField(TextAreaField):
+class QuillField(RichTextFieldMixin, TextAreaField):
     """
     A ``TextAreaField`` rendered with the Quill rich text editor.
 
@@ -164,7 +182,7 @@ class QuillField(TextAreaField):
         )
 
 
-class SummernoteField(TextAreaField):
+class SummernoteField(RichTextFieldMixin, TextAreaField):
     """
     A ``TextAreaField`` rendered with the Summernote rich text editor.
 

--- a/sqladmin/templates/sqladmin/editors/ckeditor5.html
+++ b/sqladmin/templates/sqladmin/editors/ckeditor5.html
@@ -18,6 +18,8 @@
     }
     el.dataset.ckInitialized = "1";
     el.style.resize = "none";
+    // Hidden required textareas block submit in Chrome ("not focusable").
+    el.removeAttribute("required");
 
     ClassicEditor.create(el)
       .then(function (editor) {
@@ -28,6 +30,13 @@
             editor.editing.view.document.getRoot()
           );
         });
+
+        var form = el.closest("form");
+        if (form) {
+          form.addEventListener("submit", function () {
+            editor.updateSourceElement();
+          });
+        }
       })
       .catch(function (err) {
         console.error("CKEditor5 init error for", fieldId, err);

--- a/sqladmin/templates/sqladmin/editors/quill.html
+++ b/sqladmin/templates/sqladmin/editors/quill.html
@@ -9,6 +9,8 @@
     return;
   }
   textarea.dataset.quillInitialized = "1";
+  // Hidden required textareas block submit in Chrome ("not focusable").
+  textarea.removeAttribute("required");
 
   var container = document.createElement("div");
   container.style.minHeight = minHeight + "px";

--- a/sqladmin/templates/sqladmin/editors/summernote.html
+++ b/sqladmin/templates/sqladmin/editors/summernote.html
@@ -9,6 +9,8 @@
         return;
       }
       $el.data("summernoteInitialized", true);
+      // Hidden required textareas block submit in Chrome ("not focusable").
+      $el.removeAttr("required");
       $el.summernote({
         height: height,
         disableDragAndDrop: true,

--- a/sqladmin/templates/sqladmin/editors/tinymce.html
+++ b/sqladmin/templates/sqladmin/editors/tinymce.html
@@ -1,6 +1,11 @@
 <script>
   (function () {
     var fieldId = "{{ field.id }}";
+    var el = document.getElementById(fieldId);
+    if (el) {
+      // Hidden required textareas block submit in Chrome ("not focusable").
+      el.removeAttribute("required");
+    }
     tinymce.init({
       selector: "#" + fieldId,
       plugins: "{{ field.plugins }}",

--- a/tests/test_rich_text_editors.py
+++ b/tests/test_rich_text_editors.py
@@ -117,6 +117,31 @@ def test_ckeditor5_field_init_template() -> None:
     assert CKEditor5Field.editor_init_template == "sqladmin/editors/ckeditor5.html"
 
 
+@pytest.mark.parametrize(
+    "field_class",
+    [CKEditor5Field, TinyMCEField, QuillField, SummernoteField],
+)
+def test_editor_fields_suppress_html5_required(field_class: type) -> None:
+    """Hidden required textareas block Chrome submit ("not focusable")."""
+    from wtforms.validators import InputRequired
+
+    field = _bind(field_class, validators=[InputRequired()])
+    assert field.flags.required
+    html = str(field())
+    assert "required" not in html
+
+
+def test_create_page_editor_textarea_not_html_required() -> None:
+    class PostAdmin(ModelView, model=Post):
+        form_overrides = {"content": CKEditor5Field}
+
+    with _make_client(PostAdmin) as c:
+        response = c.get("/admin/post/create")
+    assert 'id="content"' in response.text
+    assert 'id="content" name="content" required' not in response.text
+    assert "removeAttribute" in response.text
+
+
 def test_tinymce_field_media() -> None:
     field = _bind(TinyMCEField, api_key="my-key")
     assert any("tinymce.min.js" in url for url in field.media.js)


### PR DESCRIPTION
For required fields overriden with editors, it was impossible to save the content, because the editors hid textarea and render their own, and that textarea stays required (as field is required), which stops from saving. Now, before hiding it, we make them non-required, to unblock the save.