### PR TITLE
Category Menu collapses fix

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -93,6 +93,10 @@ The metadata for the model. The options are:
 - `category`: Category name to display group of `ModelView` classes together in dropdown.
 - `category_icon`: Category icon to display.
 
+Category groups start collapsed. Expanding or collapsing one group leaves the
+others untouched, and the state is remembered per admin instance in the
+browser's `localStorage`, so it survives navigating between pages.
+
 !!! example
 
     ```python

--- a/sqladmin/statics/js/main.js
+++ b/sqladmin/statics/js/main.js
@@ -622,3 +622,80 @@ function formatImportTemplate(template, values) {
     return Object.prototype.hasOwnProperty.call(values, key) ? values[key] : match;
   });
 }
+
+// Remember which sidebar category groups are expanded.
+//
+// The menu is server rendered, so every click on it reloads the whole page.
+// Without this, each navigation resets every group back to its default state.
+// The expanded groups are stored per admin instance, and Bootstrap's dropdowns
+// are configured with `data-bs-auto-close="false"` so toggling one group never
+// touches the others.
+(function () {
+  var navbar = document.querySelector('[data-sqladmin-menu]');
+  if (!navbar) return;
+
+  var storageKey = 'sqladmin:menu:' + (navbar.getAttribute('data-sqladmin-menu') || '');
+
+  // localStorage throws when it is unavailable (private mode, disabled site
+  // data) and the stored value can be stale, so every access is guarded. A
+  // failure only costs the user the remembered state, the menu still works.
+  function readExpanded() {
+    try {
+      var stored = JSON.parse(window.localStorage.getItem(storageKey));
+      return Array.isArray(stored) ? stored : [];
+    } catch (error) {
+      return [];
+    }
+  }
+
+  function writeExpanded(names) {
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(names));
+    } catch (error) {
+      // Ignored on purpose, see above.
+    }
+  }
+
+  function categoryNameOf(element) {
+    var item = element && element.closest
+      ? element.closest('[data-sqladmin-menu-category]')
+      : null;
+    return item ? item.getAttribute('data-sqladmin-menu-category') : null;
+  }
+
+  function rememberCategory(name, isExpanded) {
+    var names = readExpanded().filter(function (stored) { return stored !== name; });
+    if (isExpanded) names.push(name);
+    writeExpanded(names);
+  }
+
+  // Bootstrap marks both the toggle and the menu with `show`, and reads the
+  // class back off the toggle to decide what a click should do. Restoring only
+  // one of the two makes the next click a no-op.
+  var expanded = readExpanded();
+  Array.prototype.forEach.call(
+    navbar.querySelectorAll('[data-sqladmin-menu-category]'),
+    function (item) {
+      var name = item.getAttribute('data-sqladmin-menu-category');
+      if (expanded.indexOf(name) === -1) return;
+
+      var toggle = item.querySelector('[data-bs-toggle="dropdown"]');
+      var dropdown = item.querySelector('.dropdown-menu');
+      if (!toggle || !dropdown) return;
+
+      toggle.classList.add('show');
+      toggle.setAttribute('aria-expanded', 'true');
+      dropdown.classList.add('show');
+    }
+  );
+
+  document.addEventListener('shown.bs.dropdown', function (event) {
+    var name = categoryNameOf(event.target);
+    if (name !== null) rememberCategory(name, true);
+  });
+
+  document.addEventListener('hidden.bs.dropdown', function (event) {
+    var name = categoryNameOf(event.target);
+    if (name !== null) rememberCategory(name, false);
+  });
+})();

--- a/sqladmin/templates/sqladmin/_macros.html
+++ b/sqladmin/templates/sqladmin/_macros.html
@@ -1,14 +1,14 @@
 {% macro menu_category(menu, request) %}
 {% if menu.is_visible(request) and menu.is_accessible(request) %}
-<li class="nav-item dropdown">
+<li class="nav-item dropdown" data-sqladmin-menu-category="{{ menu.name }}">
   <a class="nav-link dropdown-toggle {% if menu.is_active(request) %}active{% endif %}" data-bs-toggle="dropdown"
-    href="#">
+    data-bs-auto-close="false" href="#" role="button" aria-expanded="false">
     <span class="nav-link-icon d-md-none d-lg-inline-block">
       {% if menu.icon %}<i class="{{ menu.icon }}"></i>{% endif %}
     </span>
     <span class="nav-link-title">{{ menu.display_name }}</span>
   </a>
-  <div class="dropdown-menu show">
+  <div class="dropdown-menu">
     <div class="dropdown-menu-columns">
       <div class="dropdown-menu-column">
         {% for sub_menu in menu.children %}

--- a/sqladmin/templates/sqladmin/layout.html
+++ b/sqladmin/templates/sqladmin/layout.html
@@ -13,7 +13,8 @@
           {% endif %}
         </a>
       </h1>
-      <nav class="navbar navbar-expand-sm shadow-none" id="navbar-menu">
+      <nav class="navbar navbar-expand-sm shadow-none" id="navbar-menu"
+        data-sqladmin-menu="{{ admin.base_url }}">
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
           aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,9 +1,15 @@
+from collections.abc import Generator
+
+import pytest
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import declarative_base
+from starlette.applications import Starlette
 from starlette.requests import Request
+from starlette.testclient import TestClient
 
-from sqladmin import ModelView
+from sqladmin import Admin, ModelView
 from sqladmin._menu import CategoryMenu, ItemMenu, Menu, ViewMenu
+from tests.common import sync_engine as engine
 
 Base = declarative_base()  # type: ignore
 
@@ -93,3 +99,44 @@ def test_menu():
 
     assert len(menu.items) == 1
     assert len(menu.items.pop().children) == 2
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    app = Starlette()
+    admin = Admin(app=app, engine=engine)
+
+    class AccountsUserAdmin(ModelView, model=User):
+        category = "Accounts"
+
+    admin.add_view(AccountsUserAdmin)
+
+    with TestClient(app=app, base_url="http://testserver") as c:
+        yield c
+
+
+def test_category_menu_is_not_force_expanded(client: TestClient) -> None:
+    # Regression test for #861: `show` used to be hardcoded on every category
+    # dropdown. Every page load therefore re-expanded all groups, and because
+    # Bootstrap reads `show` back off the *toggle* rather than the menu, the
+    # first click on a category did nothing.
+    response = client.get("/admin")
+
+    assert response.status_code == 200
+    assert '<div class="dropdown-menu show">' not in response.text
+    assert '<div class="dropdown-menu">' in response.text
+
+
+def test_category_menu_exposes_state_hooks(client: TestClient) -> None:
+    # The expanded/collapsed state is restored client side, which needs a
+    # stable key per category and a storage scope per admin instance.
+    response = client.get("/admin")
+
+    assert response.status_code == 200
+    assert (
+        '<li class="nav-item dropdown" data-sqladmin-menu-category="Accounts">'
+        in response.text
+    )
+    assert 'data-sqladmin-menu="/admin"' in response.text
+    # Without this, opening one group makes Bootstrap collapse all the others.
+    assert 'data-bs-auto-close="false"' in response.text


### PR DESCRIPTION
Closes #861. By default, all menus are closed, and the current state is stored in localStorage and state is kept between pages.